### PR TITLE
changed ontology and made new branch

### DIFF
--- a/data/climate_obstruction_1-30-25.ttl
+++ b/data/climate_obstruction_1-30-25.ttl
@@ -3702,6 +3702,13 @@ Source: https://en.wikipedia.org/wiki/Proposition""" .
                dct:created "2025-01-17T21:44:35Z"^^xsd:dateTime .
 
 
+###  https://www.michaeldebellis.com/climate_obstruction/Report
+:Report rdf:type owl:Class ;
+        rdfs:subClassOf :Document ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-31T04:39:00Z"^^xsd:dateTime .
+
+
 ###  https://www.michaeldebellis.com/climate_obstruction/Selective_Disclosure
 :Selective_Disclosure rdf:type owl:Class ;
                       rdfs:subClassOf :Impact ;
@@ -4206,6 +4213,15 @@ Most of the copies of the 10 agreements were obtained through public record act 
                   dct:created "2025-01-29T18:22:44Z"^^xsd:dateTime .
 
 
+###  https://www.michaeldebellis.com/climate_obstruction/Challenging_Climate_Change_The_Denial_Countermovement
+:Challenging_Climate_Change_The_Denial_Countermovement rdf:type owl:NamedIndividual ,
+                                                                :Journal_Article ;
+                                                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                       dct:created "2025-01-31T04:19:22Z"^^xsd:dateTime ;
+                                                       rdfs:label "Challenging Climate Change: The Denial Countermovement" ;
+                                                       :url <https://www.researchgate.net/publication/291353557_Challenging_Climate_Change_The_Denial_Countermovement#fullTextFileContent> .
+
+
 ###  https://www.michaeldebellis.com/climate_obstruction/Chile
 :Chile rdf:type owl:NamedIndividual ,
                 :Nation ;
@@ -4272,11 +4288,29 @@ The Court, therefore, granted the appeal and ordered that the application be rem
                                                :url <https://climatecasechart.com/non-us-case/coolglass-windfarm-limited-v-an-bord-pleanala-2025-iehc-1/> .
 
 
+###  https://www.michaeldebellis.com/climate_obstruction/Corporate_promotion_and_climate_change
+:Corporate_promotion_and_climate_change rdf:type owl:NamedIndividual ,
+                                                 :Journal_Article ;
+                                        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                        dct:created "2025-01-31T04:40:53Z"^^xsd:dateTime ;
+                                        rdfs:label "Corporate promotion and climate change: an analysis of key variables affecting advertising spending by major oil corporations, 1986–2015" ;
+                                        :url <https://link.springer.com/article/10.1007/s10584-019-02582-8> .
+
+
 ###  https://www.michaeldebellis.com/climate_obstruction/Decided
 :Decided rdf:type owl:NamedIndividual ,
                   :Status ;
          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
          dct:created "2025-01-29T22:17:33Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Discourses_of_climate_delay
+:Discourses_of_climate_delay rdf:type owl:NamedIndividual ,
+                                      :Journal_Article ;
+                             dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                             dct:created "2025-01-31T04:35:28Z"^^xsd:dateTime ;
+                             rdfs:label "Discourses of climate delay" ;
+                             :url <https://www.cambridge.org/core/journals/global-sustainability/article/discourses-of-climate-delay/7B11B722E3E3454BB6212378E32985A7> .
 
 
 ###  https://www.michaeldebellis.com/climate_obstruction/Europe
@@ -4301,6 +4335,15 @@ The Court, therefore, granted the appeal and ordered that the application be rem
                        <https://w3id.org/semanticarts/ns/ontology/gist/hasPhysicalLocation> :Ireland ;
                        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
                        dct:created "2025-01-30T02:58:58Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Institutionalizing_delay_foundation_funding_and_the_creation_of_US_climate_change_counter-movement_organizations
+:Institutionalizing_delay_foundation_funding_and_the_creation_of_US_climate_change_counter-movement_organizations rdf:type owl:NamedIndividual ,
+                                                                                                                           :Journal_Article ;
+                                                                                                                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                                                                                  dct:created "2025-01-31T04:26:25Z"^^xsd:dateTime ;
+                                                                                                                  rdfs:label "Institutionalizing delay: foundation funding and the creation of U.S. climate change counter-movement organizations" ;
+                                                                                                                  :url <https://link.springer.com/article/10.1007/s10584-013-1018-7> .
 
 
 ###  https://www.michaeldebellis.com/climate_obstruction/Introduction_The_First_Portrait_of_Climate_Obstruction_across_Europe
@@ -4344,6 +4387,15 @@ The Court, therefore, granted the appeal and ordered that the application be rem
 and Sociology at Brown University and the executive director of the
 Climate Social Science Network (CSSN). His current research focuses
 on social drivers of action and inaction on climate change""" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Network_structure_and_influence_of_the_climate_change_counter-movement
+:Network_structure_and_influence_of_the_climate_change_counter-movement rdf:type owl:NamedIndividual ,
+                                                                                 :Journal_Article ;
+                                                                        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                                        dct:created "2025-01-31T04:42:34Z"^^xsd:dateTime ;
+                                                                        rdfs:label "Network structure and influence of the climate change counter-movement" ;
+                                                                        :url <https://www.nature.com/articles/nclimate2875> .
 
 
 ###  https://www.michaeldebellis.com/climate_obstruction/North_America
@@ -4409,11 +4461,65 @@ The contested advertising concerned a sticker on Chiquita's bananas which includ
             dct:created "2025-01-29T18:40:04Z"^^xsd:dateTime .
 
 
+###  https://www.michaeldebellis.com/climate_obstruction/Smoke_Mirrors_Hot_Air
+:Smoke_Mirrors_Hot_Air rdf:type owl:NamedIndividual ,
+                                :Report ;
+                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                       dct:created "2025-01-31T04:37:25Z"^^xsd:dateTime ;
+                       rdfs:label "Smoke, Mirrors & Hot Air: How ExxonMobil Uses Big Tobacco's Tactics to \"Manufacture Uncertainty\" on Climate Change" ;
+                       :url <https://www.ucsusa.org/resources/smoke-mirrors-hot-air> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Sources_and_Amplifiers_of_Climate_Change_Denial
+:Sources_and_Amplifiers_of_Climate_Change_Denial rdf:type owl:NamedIndividual ,
+                                                          :Journal_Article ;
+                                                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                 dct:created "2025-01-31T04:17:33Z"^^xsd:dateTime ;
+                                                 rdfs:label "Sources and Amplifiers of Climate Change Denial" ;
+                                                 :url <https://www.researchgate.net/publication/346088327_Sources_and_Amplifiers_of_Climate_Change_Denial> .
+
+
 ###  https://www.michaeldebellis.com/climate_obstruction/South_America
 :South_America rdf:type owl:NamedIndividual ,
                         :Continent ;
                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
                dct:created "2025-01-31T02:40:07Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Strategy_in_Information_and_Influence_Campaigns
+:Strategy_in_Information_and_Influence_Campaigns rdf:type owl:NamedIndividual ,
+                                                          :Book ;
+                                                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                 dct:created "2025-01-31T04:28:19Z"^^xsd:dateTime ;
+                                                 rdfs:label "Strategy in Information and Influence Campaigns How Policy Advocates, Social Movements, Insurgent Groups, Corporations, Governments and Others Get What They Want" ;
+                                                 :url <https://www.routledge.com/Strategy-in-Information-and-Influence-Campaigns-How-Policy-Advocates-Social/Manheim/p/book/9780415887298> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Text-mining_the_signals_of_climate_change_doubt
+:Text-mining_the_signals_of_climate_change_doubt rdf:type owl:NamedIndividual ,
+                                                          :Journal_Article ;
+                                                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                 dct:created "2025-01-31T04:22:59Z"^^xsd:dateTime ;
+                                                 rdfs:label "Text-mining the signals of climate change doubt" ;
+                                                 :url <https://www.sciencedirect.com/science/article/abs/pii/S0959378015300728?casa_token=RFYHWK5WkwkAAAAA:5QTDaWIlNNANq7awL4hQZFiSUHYwt469h2IsKqIutT5WbSVlW2jvGLRNncL1CqSCPFL4XwOhWoI> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/The_Structure_and_Culture_of_Climate_Change_Denial
+:The_Structure_and_Culture_of_Climate_Change_Denial rdf:type owl:NamedIndividual ,
+                                                             :Journal_Article ;
+                                                    dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                    dct:created "2025-01-31T04:21:07Z"^^xsd:dateTime ;
+                                                    rdfs:label "The Structure and Culture of Climate Change Denial" ;
+                                                    :url <https://www.asanet.org/footnotes-article/structure-and-culture-climate-change-denial/> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/The_growth_of_climate_change_misinformation_in_US_philanthropy
+:The_growth_of_climate_change_misinformation_in_US_philanthropy rdf:type owl:NamedIndividual ,
+                                                                         :Journal_Article ;
+                                                                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                                dct:created "2025-01-31T04:45:20Z"^^xsd:dateTime ;
+                                                                rdfs:label "The growth of climate change misinformation in US philanthropy: evidence from natural language processing" ;
+                                                                :url <https://cssn.org/wp-content/uploads/2020/12/The-growth-of-climate-change-misinformation-in-US-philanthropy-evidence-from-natural-language-processing-Justin-Farrell.pdf> .
 
 
 ###  https://www.michaeldebellis.com/climate_obstruction/USA
@@ -4430,6 +4536,15 @@ The contested advertising concerned a sticker on Chiquita's bananas which includ
                 <https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn> :Europe ;
                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
                 dct:created "2025-01-31T02:52:16Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/diagram-the-structure-of-obstruction
+:diagram-the-structure-of-obstruction rdf:type owl:NamedIndividual ,
+                                               <https://w3id.org/semanticarts/ns/ontology/gist/FormattedContent> ;
+                                      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                      dct:created "2025-01-31T04:32:50Z"^^xsd:dateTime ;
+                                      rdfs:label "CSSN Primer Diagram: The Structure of Obstruction" ;
+                                      :url <https://www.asanet.org/wp-content/uploads/diagram-the-structure-of-obstruction.pdf> .
 
 
 ###  https://www.michaeldebellis.com/climate_obstruction/Federal_Public_Prosecutor’s_Office_v_Érico_Batista_de_Souza

--- a/data/climate_obstruction_1-30-25.ttl
+++ b/data/climate_obstruction_1-30-25.ttl
@@ -1,0 +1,4454 @@
+@prefix : <https://www.michaeldebellis.com/climate_obstruction/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <https://www.michaeldebellis.com/climate_obstruction/> .
+
+<https://www.michaeldebellis.com/climate_obstruction> rdf:type owl:Ontology ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "gist is a minimalist upper ontology created by Semantic Arts." ;
+                                                       <http://www.w3.org/2004/02/skos/core#historyNote> """gist 13.0.0 released 2024-Jul-24.
+        gist 12.1.0 released 2024-Feb-27.
+        gist 12.0.1 released 2023-Jul-28.
+        gist 12.0.0 released 2023-Jul-05.
+        gist 11.1.0 released 2022-Oct-10.
+        gist 11.0.0 released 2022-Apr-11.""" ;
+                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "gist" ;
+                                                       <https://w3id.org/semanticarts/ns/ontology/gist/license> "https://creativecommons.org/licenses/by/4.0/" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/contributor
+dct:contributor rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/created
+dct:created rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+<http://www.w3.org/2004/02/skos/core#altLabel> rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+<http://www.w3.org/2004/02/skos/core#definition> rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#editorialNote
+<http://www.w3.org/2004/02/skos/core#editorialNote> rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+<http://www.w3.org/2004/02/skos/core#example> rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#historyNote
+<http://www.w3.org/2004/02/skos/core#historyNote> rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#prefLabel
+<http://www.w3.org/2004/02/skos/core#prefLabel> rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#scopeNote
+<http://www.w3.org/2004/02/skos/core#scopeNote> rdf:type owl:AnnotationProperty .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/domainIncludes
+<https://w3id.org/semanticarts/ns/ontology/gist/domainIncludes> rdf:type owl:AnnotationProperty ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Relates a property to a class that the property is expected to be used on." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> "The domain of the property gist:containedText includes gist:Tag and gist:Text." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "domain includes" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "There may be multiple domainIncludes assertions on a single property." ,
+                                                                                                                "This property is used to guide the ontology user; like all annotation properties, it does not play a role in inference." ;
+                                                                rdfs:subPropertyOf <http://www.w3.org/2004/02/skos/core#scopeNote> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isSupersededBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isSupersededBy> rdf:type owl:AnnotationProperty ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Relates a deprecated term to a term that replaces it, which is either an exact (in the case of simple renaming) or approximate (in the case of renaming and some semantic change) semantic match." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> "gist:connectedTo gist:isSupersededBy gist:isConnectedTo (renaming with no semantic change)." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "is superseded by" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/license
+<https://w3id.org/semanticarts/ns/ontology/gist/license> rdf:type owl:AnnotationProperty ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "An annotation for providing the licensing on this or derivative ontologies" ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "license" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/rangeIncludes
+<https://w3id.org/semanticarts/ns/ontology/gist/rangeIncludes> rdf:type owl:AnnotationProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Relates a property to a class that is an expected type of its values." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "The range of the property gist:isCategorizedBy includes gist:Category." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "range includes" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "There may be multiple rangeIncludes assertions on a single property." ,
+                                                                                                               "This property is used to guide the ontology user; like all annotation properties, it does not play a role in inference." ;
+                                                               rdfs:subPropertyOf <http://www.w3.org/2004/02/skos/core#scopeNote> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/expert_sources
+:expert_sources rdf:type owl:AnnotationProperty ;
+                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                dct:created "2025-01-23T21:34:53Z"^^xsd:dateTime ;
+                rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/funding
+:funding rdf:type owl:AnnotationProperty ;
+         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+         dct:created "2025-01-23T21:31:37Z"^^xsd:dateTime ;
+         rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/funding_and_political_service
+:funding_and_political_service rdf:type owl:AnnotationProperty ;
+                               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                               dct:created "2025-01-24T23:47:47Z"^^xsd:dateTime ;
+                               rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/funding_and_research_agendas
+:funding_and_research_agendas rdf:type owl:AnnotationProperty ;
+                              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                              dct:created "2025-01-23T21:38:34Z"^^xsd:dateTime ;
+                              rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/influence
+:influence rdf:type owl:AnnotationProperty ;
+           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+           dct:created "2025-01-23T21:29:25Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/information_stories
+:information_stories rdf:type owl:AnnotationProperty ;
+                     dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                     dct:created "2025-01-23T21:35:47Z"^^xsd:dateTime ;
+                     rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/legitimacy_and_talent
+:legitimacy_and_talent rdf:type owl:AnnotationProperty ;
+                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                       dct:created "2025-01-23T21:36:34Z"^^xsd:dateTime ;
+                       rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/lobby_for_policy_proposals
+:lobby_for_policy_proposals rdf:type owl:AnnotationProperty ;
+                            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                            dct:created "2025-01-23T21:37:37Z"^^xsd:dateTime ;
+                            rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/membership
+:membership rdf:type owl:AnnotationProperty ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-23T21:51:16Z"^^xsd:dateTime ;
+            rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/money
+:money rdf:type owl:AnnotationProperty ;
+       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+       dct:created "2025-01-23T21:34:08Z"^^xsd:dateTime ;
+       rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/policy_proposals_at_hearings
+:policy_proposals_at_hearings rdf:type owl:AnnotationProperty ;
+                              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                              dct:created "2025-01-24T23:40:23Z"^^xsd:dateTime ;
+                              rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/political_mobilization
+:political_mobilization rdf:type owl:AnnotationProperty ;
+                        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                        dct:created "2025-01-23T21:33:30Z"^^xsd:dateTime ;
+                        rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/press_events
+:press_events rdf:type owl:AnnotationProperty ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-23T21:32:01Z"^^xsd:dateTime ;
+              rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/support_political_policies
+:support_political_policies rdf:type owl:AnnotationProperty ;
+                            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                            dct:created "2025-01-23T21:35:25Z"^^xsd:dateTime ;
+                            rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/testimony_at_hearings
+:testimony_at_hearings rdf:type owl:AnnotationProperty ;
+                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                       dct:created "2025-01-23T21:36:12Z"^^xsd:dateTime ;
+                       rdfs:subPropertyOf :influence .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/url
+:url rdf:type owl:AnnotationProperty ;
+     dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+     dct:created "2025-01-29T18:28:19Z"^^xsd:dateTime ;
+     <http://www.w3.org/2004/02/skos/core#definition> "A url associated with the entity. E.g., for an organization, the organization's web site, for a Person, the Person's web site, academia.edu page, etc." ;
+     rdfs:range xsd:anyURI .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/accepts
+<https://w3id.org/semanticarts/ns/ontology/gist/accepts> rdf:type owl:ObjectProperty ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "The types of input messages that will be allowed." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "accepts" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/allows
+<https://w3id.org/semanticarts/ns/ontology/gist/allows> rdf:type owl:ObjectProperty ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "The intention (say a grant) allows a particular kind of activity (for instance egress)" ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "allows" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/comesFromAgent
+<https://w3id.org/semanticarts/ns/ontology/gist/comesFromAgent> rdf:type owl:ObjectProperty ;
+                                                                rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> ;
+                                                                rdfs:range [ rdf:type owl:Class ;
+                                                                             owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                         )
+                                                                           ] ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "The party that is the source of something (e.g. a message, shipment, etc.)" ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "comes from agent" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "This is not the inverse of gist:goesToAgent. A message can be to someone. If we made it the inverse the person would be \"from\" the message" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/comesFromPlace
+<https://w3id.org/semanticarts/ns/ontology/gist/comesFromPlace> rdf:type owl:ObjectProperty ;
+                                                                rdfs:range [ rdf:type owl:Class ;
+                                                                             owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Address>
+                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Place>
+                                                                                         )
+                                                                           ] ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Origin" ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "comes from place" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/conformsTo
+<https://w3id.org/semanticarts/ns/ontology/gist/conformsTo> rdf:type owl:ObjectProperty ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "The subject conforms to the Object, e.g. meet an obligation, meet terms of an offer, adhere to a specification" ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "conforms to" ;
+                                                            <https://w3id.org/semanticarts/ns/ontology/gist/rangeIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/Intention> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/contributesTo
+<https://w3id.org/semanticarts/ns/ontology/gist/contributesTo> rdf:type owl:ObjectProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "The parts of a system contribute to the goal/ function of the whole system" ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "contributes to" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/goesToAgent
+<https://w3id.org/semanticarts/ns/ontology/gist/goesToAgent> rdf:type owl:ObjectProperty ;
+                                                             rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> ;
+                                                             rdfs:range [ rdf:type owl:Class ;
+                                                                          owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                        <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                      )
+                                                                        ] ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "The party that is the recipient of something (e.g. a message, shipment, etc.)" ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "goes to agent" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "This is not the inverse of gist:comesFromAgent. A message can be from someone. If we made it the inverse the person would be \"to\" the message" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/goesToPlace
+<https://w3id.org/semanticarts/ns/ontology/gist/goesToPlace> rdf:type owl:ObjectProperty ;
+                                                             rdfs:range [ rdf:type owl:Class ;
+                                                                          owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Address>
+                                                                                        <https://w3id.org/semanticarts/ns/ontology/gist/Place>
+                                                                                      )
+                                                                        ] ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "Destination" ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "goes to place" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasAccuracy
+<https://w3id.org/semanticarts/ns/ontology/gist/hasAccuracy> rdf:type owl:ObjectProperty ,
+                                                                      owl:FunctionalProperty ;
+                                                             rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "Relates a magnitude to the accuracy of its numeric value." ;
+                                                             <http://www.w3.org/2004/02/skos/core#example> "Temperature accurate to tenth of a degree C; length accurate to the nearest centimeter." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "has accuracy" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> """A typical way to use accuracy is to have it represent 2 standard deviations of the distribution of measurement errors. With this convention, when the measurement method is well-calibrated (has an average error of zero) and its errors have a normal distribution, there is a 95% chance that the actual error in measurement, in either direction, is less than the accuracy.
+
+Note that the unit of measure of the accuracy has to be compatible with the unit of measure of the original magnitude (e.g. something measured in meters could have a accuracy in terms of millimeters or any other unit that measures distance).""" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasAddend
+<https://w3id.org/semanticarts/ns/ontology/gist/hasAddend> rdf:type owl:ObjectProperty ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Relates an aspect to another aspect that is an additive component of it." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "In the equation 'profit = revenue - expenses', revenue is an addend and expenses is a subtrahend." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "has addend" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "Commonly used with financial metrics." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasAddress
+<https://w3id.org/semanticarts/ns/ontology/gist/hasAddress> rdf:type owl:ObjectProperty ;
+                                                            rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Address> ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Relates something to its physical or electronic address." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "A brick-and-mortar store has a street address. A person can be contacted electronically via an email address." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "has address" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasAspect
+<https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> rdf:type owl:ObjectProperty ,
+                                                                    owl:FunctionalProperty ;
+                                                           rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Relates a magnitude to its aspect (measurable characteristic)." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "has aspect" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasBiologicalParent
+<https://w3id.org/semanticarts/ns/ontology/gist/hasBiologicalParent> rdf:type owl:ObjectProperty ;
+                                                                     rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/LivingThing> ;
+                                                                     rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/LivingThing> ;
+                                                                     rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                     <http://www.w3.org/2004/02/skos/core#definition> "Relates a living thing to its biological parent." ;
+                                                                     <http://www.w3.org/2004/02/skos/core#prefLabel> "has biological parent" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasBroader
+<https://w3id.org/semanticarts/ns/ontology/gist/hasBroader> rdf:type owl:ObjectProperty ,
+                                                                     owl:TransitiveProperty ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Relates a thing to another thing with a broader meaning." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "The aspect distance is broader than the aspect height." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "has broader" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasDirectBroader
+<https://w3id.org/semanticarts/ns/ontology/gist/hasDirectBroader> rdf:type owl:ObjectProperty ;
+                                                                  rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasBroader> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "Relates a thing to another thing with a broader meaning, when there is no intermediate between them." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "has direct broader" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "Unlike gist:hasBroader, this property is not transitive. It is safest to use this property when semantic directness is inherent in the relationship. Otherwise, there is a risk of making a hasDirectBroader assertion and then later inserting an intermediate part; this will result in making an asserted triple false even though there was no change in the world. When in doubt, use the transitive version gist:hasBroader." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasDivisor
+<https://w3id.org/semanticarts/ns/ontology/gist/hasDivisor> rdf:type owl:ObjectProperty ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Relates a unit of measure to another unit of measure that is a divisor, or relates an aspect to another aspect that is a divisor." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "Miles per hour has miles as a multiplier and hour as a divisor." ,
+                                                                                                          "Speed has distance as a multiplier and duration as a divisor." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "has divisor" ;
+                                                            <http://www.w3.org/2004/02/skos/core#scopeNote> "Provides a supplemental method of decomposing a unit of measure or an aspect into component factors. Enables dimensional analysis such as miles per hour x hours = miles." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasGiver
+<https://w3id.org/semanticarts/ns/ontology/gist/hasGiver> rdf:type owl:ObjectProperty ;
+                                                          rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> ;
+                                                          owl:propertyDisjointWith <https://w3id.org/semanticarts/ns/ontology/gist/hasRecipient> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The active party, the one with the obligation or the one initiating the transfer" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "has giver" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasGoal
+<https://w3id.org/semanticarts/ns/ontology/gist/hasGoal> rdf:type owl:ObjectProperty ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "The reason for doing something" ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "has goal" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasIncumbent
+<https://w3id.org/semanticarts/ns/ontology/gist/hasIncumbent> rdf:type owl:ObjectProperty ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "What equipment or person is currently in this node.  Note to create a temporal view make a TemporalRelation for this property" ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "has incumbent" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude
+<https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> rdf:type owl:ObjectProperty ;
+                                                              rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "Relates a thing to a magnitude." ;
+                                                              <http://www.w3.org/2004/02/skos/core#example> "A car or a model of car has a magnitude for length, one for width, one for weight, etc." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "has magnitude" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasMultiplier
+<https://w3id.org/semanticarts/ns/ontology/gist/hasMultiplier> rdf:type owl:ObjectProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Relates a unit of measure to another unit of measure that is a factor, or relates an aspect to another aspect that is a factor." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "Miles per hour has miles as a multiplier and hour as a divisor." ,
+                                                                                                             "Speed has distance as a multiplier and duration as a divisor." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "has multiplier" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "Provides a supplemental method of decomposing a unit of measure or aspect into component factors. Enables dimensional analysis such as miles per hour x hours = miles." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasNavigationalParent
+<https://w3id.org/semanticarts/ns/ontology/gist/hasNavigationalParent> rdf:type owl:ObjectProperty ;
+                                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                       <http://www.w3.org/2004/02/skos/core#definition> "Relates a child category to a parent category in an informal (e.g., faceted) hierarchy." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#example> "Refrigerator handles are not refrigerators, but it may be useful to represent their relationship hierarchically for a faceted UI filter." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "has navigational parent" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant
+<https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> rdf:type owl:ObjectProperty ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Relates something (e.g. an agreement) to things that play a role, or take part or are otherwise involved in some way." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> "An event of transferring money has a participating account that receives the money." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "has participant" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "The thing with participants will often be an agreement, event or obligation. Participation does not imply agency." ,
+                                                                                                                "This will most often be used as an abstract property. Use subproperties that indicate the nature of the participation (e.g. hasBorrower, hasVenue)." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasParty
+<https://w3id.org/semanticarts/ns/ontology/gist/hasParty> rdf:type owl:ObjectProperty ;
+                                                          rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> ;
+                                                          rdfs:range [ rdf:type owl:Class ;
+                                                                       owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                     <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                   )
+                                                                     ] ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The people or organizations participating in an event, agreement or obligation" ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "For loan agreements, one might create hasLender and hasBorrower as subproperties of hasParty." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "has party" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasPhysicalLocation
+<https://w3id.org/semanticarts/ns/ontology/gist/hasPhysicalLocation> rdf:type owl:ObjectProperty ,
+                                                                              owl:TransitiveProperty ;
+                                                                     rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                                     rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                     <http://www.w3.org/2004/02/skos/core#definition> "Relates something to its physical location." ;
+                                                                     <http://www.w3.org/2004/02/skos/core#prefLabel> "has physical location" ;
+                                                                     <http://www.w3.org/2004/02/skos/core#scopeNote> "This property does not distinguish between things whose locations are stable and those whose locations change over time; e.g., a fire hydrant vs. a car." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasRecipient
+<https://w3id.org/semanticarts/ns/ontology/gist/hasRecipient> rdf:type owl:ObjectProperty ;
+                                                              rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "The recipient" ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "has recipient" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasSubtrahend
+<https://w3id.org/semanticarts/ns/ontology/gist/hasSubtrahend> rdf:type owl:ObjectProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Relates an aspect to another aspect that is a subtracted component of it." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "In the equation 'profit = revenue - expenses', revenue is an addend and expenses is a subtrahend." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "has subtrahend" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "Commonly used with financial metrics." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasUniqueBroader
+<https://w3id.org/semanticarts/ns/ontology/gist/hasUniqueBroader> rdf:type owl:ObjectProperty ;
+                                                                  rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasBroader> ;
+                                                                  rdf:type owl:FunctionalProperty ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "Relates a thing to a unique other thing with a broader meaning." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "has unique broader" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasUniqueNavigationalParent
+<https://w3id.org/semanticarts/ns/ontology/gist/hasUniqueNavigationalParent> rdf:type owl:ObjectProperty ;
+                                                                             rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/hasNavigationalParent> ;
+                                                                             rdf:type owl:FunctionalProperty ;
+                                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                             <http://www.w3.org/2004/02/skos/core#definition> "Relates a subject category to a unique parent category in an informal (e.g., faceted) hierarchy." ;
+                                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "has unique navigational parent" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasUnitGroup
+<https://w3id.org/semanticarts/ns/ontology/gist/hasUnitGroup> rdf:type owl:ObjectProperty ;
+                                                              rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                              rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup> ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "Relates an aspect to a unit group. The aspect can be measured using any of the members of the unit group." ;
+                                                              <http://www.w3.org/2004/02/skos/core#example> "The aspect distance can have a unit group that includes the units meter, inch, foot, etc." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "has unit group" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/hasUnitOfMeasure
+<https://w3id.org/semanticarts/ns/ontology/gist/hasUnitOfMeasure> rdf:type owl:ObjectProperty ;
+                                                                  rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ;
+                                                                  rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "Relates a magnitude to a unit of measure." ,
+                                                                                                                   "The magnitude 87 inches of height has unit of measure inches." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "has unit of measure" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isAbout
+<https://w3id.org/semanticarts/ns/ontology/gist/isAbout> rdf:type owl:ObjectProperty ;
+                                                         rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Content> ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "Subject matter of a document." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "is about" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isAffectedBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isAffectedBy> rdf:type owl:ObjectProperty ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "Where the effect came from" ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "is affected by" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isAllocatedBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isAllocatedBy> rdf:type owl:ObjectProperty ;
+                                                               rdfs:range [ rdf:type owl:Class ;
+                                                                            owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty>
+                                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                        )
+                                                                          ] ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Relates the subject to whomever or whatever assigns or distributes it." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "A U.S. Social Security number is allocated by the U.S. Social Security Administration. The media type https://www.iana.org/assignments/media-types/text/csv is allocated by the Internet Assigned Numbers Authority (IANA)." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "is allocated by" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "The allocator may be a person, organization, or automated process." ;
+                                                               <https://w3id.org/semanticarts/ns/ontology/gist/domainIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/Category> ,
+                                                                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/ID> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isBasedOn
+<https://w3id.org/semanticarts/ns/ontology/gist/isBasedOn> rdf:type owl:ObjectProperty ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "The Object is a foundation for, a starting point for, gave rise to or justifies the Subject" ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "A document is based on a document template. A metric computing the average income of a population is based on the metric for individual income." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "is based on" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isCategorizedBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isCategorizedBy> rdf:type owl:ObjectProperty ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Points to a taxonomy item or other less formally defined class." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "is categorized by" ;
+                                                                 <https://w3id.org/semanticarts/ns/ontology/gist/rangeIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/Category> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isConnectedTo
+<https://w3id.org/semanticarts/ns/ontology/gist/isConnectedTo> rdf:type owl:ObjectProperty ,
+                                                                        owl:SymmetricProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "A non-owning, non-causal, non-subordinate (i.e., peer-to-peer) relationship." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "is connected to" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isDirectPartOf
+<https://w3id.org/semanticarts/ns/ontology/gist/isDirectPartOf> rdf:type owl:ObjectProperty ;
+                                                                rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/isPartOf> ;
+                                                                owl:inverseOf :has_Direct_Part ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "The relationship between a part and a whole where the part has independent existence and there are no other parts in between." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "is direct part of" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "Because the part has independent existence, there is no cascading delete." ,
+                                                                                                                "It is safest to use this property when semantic directness is inherent in the relationship, rather than simply expressing a chosen granularity. For example, a spark plug is a direct part of an engine block; there cannot be any intermediate parts. Otherwise, there is a risk of making an isDirectPartOf assertion and then later inserting an intermediate part; this will result in making an asserted triple false even though there was no change in the world. When in doubt, use the transitive version gist:isPartOf." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isExpressedIn
+<https://w3id.org/semanticarts/ns/ontology/gist/isExpressedIn> rdf:type owl:ObjectProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "The language something was expressed in" ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "is expressed in" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isFirstMemberOf
+<https://w3id.org/semanticarts/ns/ontology/gist/isFirstMemberOf> rdf:type owl:ObjectProperty ;
+                                                                 rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> ;
+                                                                 rdf:type owl:FunctionalProperty ;
+                                                                 rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember> ;
+                                                                 rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/OrderedCollection> ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Relates the first member of an ordered collection to the collection." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "is first member of" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#scopeNote> "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections need not be strictly ordered, there can be more than one first member." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn
+<https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn> rdf:type owl:ObjectProperty ,
+                                                                           owl:TransitiveProperty ;
+                                                                  rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                                  rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "Relates one place to another that contains it." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "is geographically contained in" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy> rdf:type owl:ObjectProperty ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "Relates a thing governed to the governor." ;
+                                                              <http://www.w3.org/2004/02/skos/core#example> "A country geo-region is governed by a country government." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "is governed by" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isIdentifiedBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isIdentifiedBy> rdf:type owl:ObjectProperty ,
+                                                                         owl:InverseFunctionalProperty ;
+                                                                rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/ID> ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "This is like a URI: a thing can have more than one ID, but each of the IDs must refer to a unique thing." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "is identified by" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isMadeUpOf
+<https://w3id.org/semanticarts/ns/ontology/gist/isMadeUpOf> rdf:type owl:ObjectProperty ;
+                                                            rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Relates something to a substance that it is made up of." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "The vase is made up of clay. Water is made up of hydrogen and oxygen." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "is made up of" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf
+<https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> rdf:type owl:ObjectProperty ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Relates a member individual to the thing, such as a collection or organization, that it is a member of." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "is member of" ;
+                                                            <https://w3id.org/semanticarts/ns/ontology/gist/rangeIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/Collection> ,
+                                                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Organization> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isPartOf
+<https://w3id.org/semanticarts/ns/ontology/gist/isPartOf> rdf:type owl:ObjectProperty ;
+                                                          owl:inverseOf :has_Part ;
+                                                          rdf:type owl:TransitiveProperty ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The relationship between a part and a whole where the part has independent existence." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "is part of" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "Because the part has independent existence, there is no cascading delete." ,
+                                                                                                          "The transitive version of gist:isDirectPartOf." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isRecognizedBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isRecognizedBy> rdf:type owl:ObjectProperty ;
+                                                                rdfs:range [ rdf:type owl:Class ;
+                                                                             owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                         )
+                                                                           ] ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Relates something to a party that formally acknowledges its existence, validity, or legality." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> "The existence of a particular company is recognized by the state." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "is recognized by" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isRenderedOn
+<https://w3id.org/semanticarts/ns/ontology/gist/isRenderedOn> rdf:type owl:ObjectProperty ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "What media something was rendered On" ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "is rendered on" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isTriggeredBy
+<https://w3id.org/semanticarts/ns/ontology/gist/isTriggeredBy> rdf:type owl:ObjectProperty ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Relates a contingency, such as an event or obligation, to the event that gives rise to it." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "Fire insurance is contingent on a particular building burning down" ,
+                                                                                                             "The death benefit payout on a life insurance policy following the death of a specific person." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "is triggered by" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "For obligations, this property describes what must happen to trigger the contingent obligation. Other uses include controls, processes, etc." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isUnderJurisdictionOf
+<https://w3id.org/semanticarts/ns/ontology/gist/isUnderJurisdictionOf> rdf:type owl:ObjectProperty ;
+                                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                       <http://www.w3.org/2004/02/skos/core#definition> "Relates a law, contract, etc., to the system of law or government which has the power, right, or authority to interpret and apply it." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "is under jurisdiction of" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/links
+<https://w3id.org/semanticarts/ns/ontology/gist/links> rdf:type owl:ObjectProperty ;
+                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Relates a NetworkLink to a NetworkNode that it connects to another node. Used when the connections are undirected, or the direction is not known." ;
+                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "links" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/linksFrom
+<https://w3id.org/semanticarts/ns/ontology/gist/linksFrom> rdf:type owl:ObjectProperty ;
+                                                           rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/links> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Relates a NetworkLink to its origin NetworkNode. Unlike the superproperty, this represents a directed connection." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "links from" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/linksTo
+<https://w3id.org/semanticarts/ns/ontology/gist/linksTo> rdf:type owl:ObjectProperty ;
+                                                         rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/links> ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "Relates a NetworkLink to its destination NetworkNode. Unlike the superproperty, this represents a directed connection." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "links to" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/occursIn
+<https://w3id.org/semanticarts/ns/ontology/gist/occursIn> rdf:type owl:ObjectProperty ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The geospatial place where something happened or will happen" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "occurs in" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/offers
+<https://w3id.org/semanticarts/ns/ontology/gist/offers> rdf:type owl:ObjectProperty ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "Relates something to a thing that is being made available for acceptance or rejection." ;
+                                                        <http://www.w3.org/2004/02/skos/core#example> "An instance of gist:Offer offers a specific product at a particular price; a company offers an employee benefit; Honda offers vehicles for sale." ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "offers" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/owns
+<https://w3id.org/semanticarts/ns/ontology/gist/owns> rdf:type owl:ObjectProperty ;
+                                                      rdfs:domain [ rdf:type owl:Class ;
+                                                                    owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                  <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                )
+                                                                  ] ;
+                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "Possessing and controlling.  Ultimate form of ownership is the right to destroy.  Long list of potential Range classes" ;
+                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "owns" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/precedes
+<https://w3id.org/semanticarts/ns/ontology/gist/precedes> rdf:type owl:ObjectProperty ,
+                                                                   owl:TransitiveProperty ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A generic ordering relation indicating that the subject comes before the object." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "precedes" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "The less-than symbol is often used to represent this relation." ,
+                                                                                                          "This is the transitive version of gist:precedesDirectly." ,
+                                                                                                          "Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/precedesDirectly
+<https://w3id.org/semanticarts/ns/ontology/gist/precedesDirectly> rdf:type owl:ObjectProperty ;
+                                                                  rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/precedes> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "A generic ordering relation indicating that the subject comes immediately before the object." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "precedes directly" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "If two items in an ordered collection share the same position, they both directly precede the following element." ,
+                                                                                                                  "It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world." ,
+                                                                                                                  "Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/prevents
+<https://w3id.org/semanticarts/ns/ontology/gist/prevents> rdf:type owl:ObjectProperty ;
+                                                          rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ;
+                                                          rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Behavior> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The intention (say a law) is intended to prevent this kind of behavior (say jay-walking)" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "prevents" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/produces
+<https://w3id.org/semanticarts/ns/ontology/gist/produces> rdf:type owl:ObjectProperty ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The subject creates the object." ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "A task produces a deliverable." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "produces" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/providesOrderFor
+<https://w3id.org/semanticarts/ns/ontology/gist/providesOrderFor> rdf:type owl:ObjectProperty ,
+                                                                           owl:FunctionalProperty ;
+                                                                  rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "Links a member of an ordered collection to the real-world item it represents in that collection." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "provides order for" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/refersTo
+<https://w3id.org/semanticarts/ns/ontology/gist/refersTo> rdf:type owl:ObjectProperty ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "Relates something to another resource that it points to, indicates, or references." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "refers to" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/requires
+<https://w3id.org/semanticarts/ns/ontology/gist/requires> rdf:type owl:ObjectProperty ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The subject needs the object or makes it necessary, mandatory, or compulsory." ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "Humans require air; solar power requires sunshine." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "requires" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> """This predicate is defined generally enough to encompass a few different meanings of the English word 'requires':
+
+		1. To need something or to make something necessary.
+		2. To order or demand something, or to order someone to do something, especially because of a rule or law.
+		3. To make it officially necessary for someone to do something.
+
+	Implementations requiring a more specific meaning should define subproperties.""" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/has_Direct_Part
+:has_Direct_Part rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :has_Part ;
+                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                 dct:created "2025-01-29T01:00:03Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/has_Part
+:has_Part rdf:type owl:ObjectProperty ,
+                   owl:TransitiveProperty ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-29T00:59:49Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/has_author
+:has_author rdf:type owl:ObjectProperty ;
+            owl:inverseOf :is_author_of ;
+            rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Content> ;
+            rdfs:range :Agent ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-29T00:54:44Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/has_employee
+:has_employee rdf:type owl:ObjectProperty ;
+              owl:inverseOf :is_employee_of ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-29T18:26:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/has_jurisdiction
+:has_jurisdiction rdf:type owl:ObjectProperty ;
+                  owl:inverseOf :is_jurisdiction_for ;
+                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                  dct:created "2025-01-30T02:55:36Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/has_status
+:has_status rdf:type owl:ObjectProperty ;
+            rdfs:range :Status ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-29T22:19:35Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/is_author_of
+:is_author_of rdf:type owl:ObjectProperty ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-29T00:55:21Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/is_employee_of
+:is_employee_of rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> ;
+                rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+                rdfs:range <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ;
+                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                dct:created "2025-01-29T18:24:35Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/is_jurisdiction_for
+:is_jurisdiction_for rdf:type owl:ObjectProperty ;
+                     dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                     dct:created "2025-01-30T02:55:55Z"^^xsd:dateTime .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  http://purl.org/dc/terms/abstract
+dct:abstract rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :content_metadata .
+
+
+###  http://purl.org/dc/terms/publisher
+dct:publisher rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf :content_metadata .
+
+
+###  http://purl.org/dc/terms/title
+dct:title rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf :content_metadata .
+
+
+###  http://purl.org/ontology/bibo/issue
+<http://purl.org/ontology/bibo/issue> rdf:type owl:DatatypeProperty ;
+                                      rdfs:subPropertyOf :content_metadata .
+
+
+###  http://purl.org/ontology/bibo/volume
+<http://purl.org/ontology/bibo/volume> rdf:type owl:DatatypeProperty ;
+                                       rdfs:subPropertyOf :content_metadata .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualEndDate
+<https://w3id.org/semanticarts/ns/ontology/gist/actualEndDate> rdf:type owl:DatatypeProperty ;
+                                                               rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> ;
+                                                               rdfs:range xsd:dateTime ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "The actual date that something ended, with precision of one day." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T00:00:00-6:00'^^xsd:dateTime" ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "actual end date" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things where the precision of a date is sufficient, such as most projects, tasks, and the like. Recommended usage is to zero out the hours through microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> rdf:type owl:DatatypeProperty ;
+                                                                   rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/endDateTime> ;
+                                                                   rdfs:range xsd:dateTime ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "The actual date and time that something ended, with no implied precision." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "actual end date time" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "This is an abstraction over the various precisions of actual end time, and is not expected to be asserted directly. Values of predicates with different precisions can be compared since they are all formally xsd:datetimes." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualEndMicrosecond
+<https://w3id.org/semanticarts/ns/ontology/gist/actualEndMicrosecond> rdf:type owl:DatatypeProperty ;
+                                                                      rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> ;
+                                                                      rdfs:range xsd:dateTime ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "The actual time that something ended, expressed as a system time used for timestamps." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T08:03:27.12324-6:00'^^xsd:dateTime" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "actual end microsecond" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#scopeNote> "A system time will be as precise as the system can supply, typically at least milliseconds, sometimes microseconds. The convention for timestamps, such as recording a transaction, is to specify just the end point; the start time is rarely needed." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualEndMinute
+<https://w3id.org/semanticarts/ns/ontology/gist/actualEndMinute> rdf:type owl:DatatypeProperty ;
+                                                                 rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> ;
+                                                                 rdfs:range xsd:dateTime ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "The actual date and time that something ended, with precision of one minute." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T08:32:00-6:00'^^xsd:dateTime" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "actual end minute" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things like meetings and time card entries, where the hour and minute are important. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualEndYear
+<https://w3id.org/semanticarts/ns/ontology/gist/actualEndYear> rdf:type owl:DatatypeProperty ;
+                                                               rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> ;
+                                                               rdfs:range xsd:dateTime ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "The actual date that something ended, with precision of one year." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "'2021-01-01T00:00:00-6:00'^^xsd:dateTime" ,
+                                                                                                             "The tenure of the previous chairman of the board ended in 2021." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "actual end year" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualStartDate
+<https://w3id.org/semanticarts/ns/ontology/gist/actualStartDate> rdf:type owl:DatatypeProperty ;
+                                                                 rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> ;
+                                                                 rdfs:range xsd:dateTime ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "The actual date that something started, with precision of one day." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T00:00:00-6:00'^^xsd:dateTime" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "actual start date" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things where the precision of a date is sufficient, such as most projects, tasks, and the like. Recommended usage is to zero out the hours through microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> rdf:type owl:DatatypeProperty ;
+                                                                     rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/startDateTime> ;
+                                                                     rdfs:range xsd:dateTime ;
+                                                                     rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                     <http://www.w3.org/2004/02/skos/core#definition> "The actual date and time that something started, with no implied precision." ;
+                                                                     <http://www.w3.org/2004/02/skos/core#prefLabel> "actual start date time" ;
+                                                                     <http://www.w3.org/2004/02/skos/core#scopeNote> "This is an abstraction over the various precisions of actual start time, and is not expected to be asserted directly. Values of predicates with different precisions can be compared since they are all formally xsd:datetimes." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualStartMicrosecond
+<https://w3id.org/semanticarts/ns/ontology/gist/actualStartMicrosecond> rdf:type owl:DatatypeProperty ;
+                                                                        rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> ;
+                                                                        rdfs:range xsd:dateTime ;
+                                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                        <http://www.w3.org/2004/02/skos/core#definition> "The actual time that something started, expressed as a system time used for timestamps." ;
+                                                                        <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T08:03:27.12324-6:00'^^xsd:dateTime" ;
+                                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "actual start microsecond" ;
+                                                                        <http://www.w3.org/2004/02/skos/core#scopeNote> "A system time will be as precise as the system can supply, typically at least milliseconds, sometimes microseconds. The convention for timestamps, such as recording a transaction, is to specify just the end point; the start time is rarely needed. This property is defined for the cases when you do need to capture the runtime of a system process, and is then used in conjunction with gist:actualEndMicrosecond." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualStartMinute
+<https://w3id.org/semanticarts/ns/ontology/gist/actualStartMinute> rdf:type owl:DatatypeProperty ;
+                                                                   rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> ;
+                                                                   rdfs:range xsd:dateTime ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "The actual date and time that something started, with precision of one minute." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T08:32:00-6:00'^^xsd:dateTime" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "actual start minute" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things like meetings and time card entries, where the hour and minute are important. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/actualStartYear
+<https://w3id.org/semanticarts/ns/ontology/gist/actualStartYear> rdf:type owl:DatatypeProperty ;
+                                                                 rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> ;
+                                                                 rdfs:range xsd:dateTime ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "The actual date that something started, with precision of one year." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> "'2021-01-01T00:00:00-6:00'^^xsd:dateTime" ,
+                                                                                                               "The tenure of the current chairman of the board began in 2021." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "actual start year" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/atDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/atDateTime> rdf:type owl:DatatypeProperty ;
+                                                            rdfs:range xsd:dateTime ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "The date and time at which something did or will occur, with variants for precision, start and end, and actual vs. planned." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "at date time" ;
+                                                            <http://www.w3.org/2004/02/skos/core#scopeNote> """This is the top level property for asserting time, and is not expected to be asserted directly.
+
+The subproperties allow the ontologist to do three things:
+1) Distinguish start and end times.
+2) Indicate whether a time is planned or actual. This is useful for everything from project management to calendar appointments and the like. It is also useful for date effectivities; i.e., something valid up to a planned date).
+3) Distinguish varying levels of precision; sort of a simple version of the Allen functions.
+
+All datetimes are of the same format: '2021-06-01T08:03:27.12324-6:00'^^xsd:dateTime. This is compatible with and a subset of ISO 8601.
+
+Time zone offset, such as -6:00 (of which there are a few dozen) is recognized in the date itself, as shown. The actual time zone standard (of which there are 131) may optionally be attached to the event or other object itself.
+
+There will be many historical dates that do not have a time zone offset (e.g., Lincoln's birthday, as well as about 75% of all legacy systems), and in that case the offset can be omitted.
+
+The conventions for precision that are repeated in each property name are as follows:
+	- *DateTime is an abstraction over the various precisions of its subproperties.
+	- *Date refers to a calendar date (e.g., birthdays and invoice dates) and is assumed to have precision of one day. Time zone offset is allowed.
+	- *Minute refers to clock time; e.g., a meeting will start at 9:15 with a timezone offset. Precision is assumed to have precision of one minute.
+	- *Microsecond refers to system time, and it will be as precise as the system can supply; typically at least milliseconds, sometime microseconds.""" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/birthDate
+<https://w3id.org/semanticarts/ns/ontology/gist/birthDate> rdf:type owl:DatatypeProperty ;
+                                                           rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/startDateTime> ;
+                                                           rdfs:range xsd:dateTime ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "The date some living thing was or will be born, with precision of one day." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T00:00:00-6:00'^^xsd:dateTime" ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "birth date" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "This is a subproperty of gist:startDateTime rather than gist:actualStartDate because some living things have yet to be born. This property refers to a calendar date and is assumed to precision of one day (time zone offset is allowed). It is recommended to zero out the hours through microseconds to avoid spurious precision. Implementations requiring a birthdate to the minute can define a subproperty." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/containedText
+<https://w3id.org/semanticarts/ns/ontology/gist/containedText> rdf:type owl:DatatypeProperty ;
+                                                               rdfs:range xsd:string ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "A string that is closely associated with an individual." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "The string associated with a tag." ,
+                                                                                                             "The string associated with text content." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "contained text" ;
+                                                               <https://w3id.org/semanticarts/ns/ontology/gist/domainIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/Tag> ,
+                                                                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/Text> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor
+<https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor> rdf:type owl:DatatypeProperty ,
+                                                                           owl:FunctionalProperty ;
+                                                                  rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                  rdfs:range [ rdf:type rdfs:Datatype ;
+                                                                               owl:unionOf ( xsd:decimal
+                                                                                             xsd:double
+                                                                                           )
+                                                                             ] ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  rdfs:seeAlso <https://w3id.org/semanticarts/ns/ontology/gist/conversionOffset> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "A value that relates a unit of measure to units of the International System of Units. For example, in the equation 1 inch = 0.0254 meters, the value 0.0254 is the conversion factor of inch." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "conversion factor" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> """To convert a numeric value from one unit of measure to another, multiply by the conversion factor of the first unit and then divide by the conversion factor of the second unit.
+
+	For example, to convert 27 feet to yards:
+
+		the conversion factor of foot is 0.3048
+		the conversion factor of yard is 0.9144
+
+		so
+
+		27 feet = (27 x 0.3048) / 0.9144 = 9 yards""" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/conversionOffset
+<https://w3id.org/semanticarts/ns/ontology/gist/conversionOffset> rdf:type owl:DatatypeProperty ,
+                                                                           owl:FunctionalProperty ;
+                                                                  rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                  rdfs:range xsd:decimal ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> """A value used along with a conversion factor to relate a unit to its corresponding unit in the International System of Units. In the equation below, the conversion offset is 459.669607 and the conversion factor is 5/9.
+
+		y degrees Fahrenheit = (y + 459.669607) x 5/9 degrees Kelvin
+
+		To convert from Fahrenheit to Kelvin, first add the offset and then multiply by the conversion factor.
+
+		To convert from Kelvin to Fahrenheit, reverse the steps: first divide by the conversion factor and then subtract the offset.""" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "conversion offset" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/deathDate
+<https://w3id.org/semanticarts/ns/ontology/gist/deathDate> rdf:type owl:DatatypeProperty ;
+                                                           rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDate> ;
+                                                           rdfs:range xsd:dateTime ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "The date some living thing died." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T00:00:00-6:00'^^xsd:dateTime" ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "death date" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "Refers to a calendar date and is assumed to have precision of one day (time zone offset is allowed). Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Implementations requiring a death date to the minute can define a subproperty." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/description
+<https://w3id.org/semanticarts/ns/ontology/gist/description> rdf:type owl:DatatypeProperty ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "A statement about someone or something's attributes or characteristics." ;
+                                                             <http://www.w3.org/2004/02/skos/core#example> "The Empire State Building is a 102-story Art Deco skyscraper in Midtown Manhattan in New York City, United States. It was designed by Shreve, Lamb & Harmon and built from 1930 to 1931." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "description" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "This property is used to provide a description of an individual in greater detail than a label." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/encryptedText
+<https://w3id.org/semanticarts/ns/ontology/gist/encryptedText> rdf:type owl:DatatypeProperty ;
+                                                               rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/containedText> ;
+                                                               rdfs:range xsd:string ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Links to the string corresponding to EncryptedText" ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "encrypted text" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/endDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/endDateTime> rdf:type owl:DatatypeProperty ;
+                                                             rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/atDateTime> ;
+                                                             rdfs:range xsd:dateTime ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "The date and time that something ends." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "end date time" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "This property is neutral along two dimensions: precision (e.g., day, second, millisecond) and actual vs. planned. As such, it will generally not be asserted directly except in special cases (e.g., for time intervals)." ,
+                                                                                                             "Values of predicates with different precisions can be compared since they are all formally xsd:datetimes." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfAmpere
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfAmpere> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:domain [ rdf:type owl:Class ;
+                                                                                owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                              <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                            )
+                                                                              ] ;
+                                                                  rdfs:range xsd:decimal ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The exponent of ampere in a product of powers of base units." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 milliampere = 0.001 x ampere'
+
+		the conversionFactor for milliampere is 0.001
+		the exponent of ampere is 1
+		all other exponents are zero
+
+		Every member of a unit group containing milliampere must be a multiple of ampere.""" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of ampere" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfBit
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfBit> rdf:type owl:DatatypeProperty ;
+                                                               rdfs:domain [ rdf:type owl:Class ;
+                                                                             owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                         )
+                                                                           ] ;
+                                                               rdfs:range xsd:decimal ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "The exponent of bit in a product of powers of base units." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 megabit per second = 1000000 x bit per second'
+
+		the conversion factor for megabit per second is 1000000
+		the exponent of bit is 1
+		the exponent of second is -1
+		all other exponents are zero
+
+		Every member of a unit group containing megabit per second must be a multiple of bit per second.""" ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of bit" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfCandela
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfCandela> rdf:type owl:DatatypeProperty ;
+                                                                   rdfs:domain [ rdf:type owl:Class ;
+                                                                                 owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                             )
+                                                                               ] ;
+                                                                   rdfs:range xsd:decimal ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "The exponent of candela in a product of powers of base units." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 candlepower = 1 x candela'
+
+		the conversion factor for candlepower is 1
+		the exponent of candela is 1
+		all other exponents are zero
+
+		Every member of a unit group containing candlepower must be a multiple of candela.""" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of candela" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfKelvin
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfKelvin> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:domain [ rdf:type owl:Class ;
+                                                                                owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                              <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                            )
+                                                                              ] ;
+                                                                  rdfs:range xsd:decimal ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The exponent of Kelvin in a product of powers of base units." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> """In the equation 'y degrees Fahrenheit = (y + 459.6669607) x 5/9 degrees Kelvin'
+
+		the conversion offset for degree Fahrenheit is 459.6669607
+		the conversion factor for degree Fahrenheit is 5/9
+		the exponent of Kelvin is 1
+		all other exponents are zero
+
+		Every member of a unit group containing degree Fahrenheit will have a similar equation, with different offset or conversion factor (or both).""" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of Kelvin" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfKilogram
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfKilogram> rdf:type owl:DatatypeProperty ;
+                                                                    rdfs:domain [ rdf:type owl:Class ;
+                                                                                  owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                                <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                              )
+                                                                                ] ;
+                                                                    rdfs:range xsd:decimal ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The exponent of kilogram in a product of powers of base units." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 millimole per gram = 1 x mole per kilogram'
+
+		the conversion factor for millimole per gram is 1
+		the exponent of mole is 1
+		the exponent of kilogram is -1
+		all other exponents are zero
+
+		Every member of a unit group containing millimole per gram must be a multiple of mole per kilogram.""" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of kilogram" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfMeter
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfMeter> rdf:type owl:DatatypeProperty ;
+                                                                 rdfs:domain [ rdf:type owl:Class ;
+                                                                               owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                             <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                           )
+                                                                             ] ;
+                                                                 rdfs:range xsd:decimal ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "The exponent of meter in a product of powers of base units." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 microgram per milliliter = 0.001 x kilogram per meterCubed'
+
+		the conversion factor for microgram per milliliter is 0.001
+		the exponent of kilogram is 1
+		the exponent of meter is -3
+		all other exponents are zero
+
+		Every member of a unit group containing microgram per milliliter must be a multiple of kilogram per meterCubed.""" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of meter" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfMole
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfMole> rdf:type owl:DatatypeProperty ;
+                                                                rdfs:domain [ rdf:type owl:Class ;
+                                                                              owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                          )
+                                                                            ] ;
+                                                                rdfs:range xsd:decimal ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "The exponent of mole in a product of powers of base units." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 katal = 1 x mole per second'
+
+		the conversion factor for katal is 1
+		the exponent of mole is 1
+		the exponent of second is -1
+		all other exponents are zero
+
+		Every member of a unit group containing katal must be a multiple of mole per second.""" ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of mole" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfNumber
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfNumber> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:domain [ rdf:type owl:Class ;
+                                                                                owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                              <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                            )
+                                                                              ] ;
+                                                                  rdfs:range xsd:decimal ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The exponent of number in a product of powers of base units." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 beat per minute = 0.016667 x number per second'
+
+		the conversion factor for beat per minute is 0.016667
+		the exponent of number is 1
+		the exponent of second is -1
+		all other exponents are zero
+
+		Every member of a unit group containing beat per minute must be a multiple of number per second.""" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of number" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "Use when the unit of measure involves a count or other number." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfOther
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfOther> rdf:type owl:DatatypeProperty ;
+                                                                 rdfs:domain [ rdf:type owl:Class ;
+                                                                               owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                             <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                           )
+                                                                             ] ;
+                                                                 rdfs:range xsd:decimal ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Indicates whether a unit of measure can be expressed in terms of the standard exponents (as shown in the examples)." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> "Decibel, pH, and octave are units of measure that are logarithmic. Their unit groups have exponent of other = 1." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of other" ;
+                                                                 <http://www.w3.org/2004/02/skos/core#scopeNote> """Set the value to 0 if the units of measure in the unit group can be expressed using the standard set of exponents (as in the examples).
+
+		Otherwise set the value to 1, which typically means the units of measure in the group use a logarithmic scale.""" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfRadian
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfRadian> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:domain [ rdf:type owl:Class ;
+                                                                                owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                              <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                            )
+                                                                              ] ;
+                                                                  rdfs:range xsd:decimal ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The exponent of radian in a product of powers of base units." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 revolution = 6.283 x radian'
+
+		the conversion factor for revolution is 6.283
+		the exponent of radian is 1
+		all other exponents are zero
+
+		Every member of a unit group containing revolution must be a multiple of radian.""" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of radian" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfSecond
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfSecond> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:domain [ rdf:type owl:Class ;
+                                                                                owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                              <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                            )
+                                                                              ] ;
+                                                                  rdfs:range xsd:decimal ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The exponent of second in a product of powers of base units." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 watt-hour = 3600 x kilogram meterSquared per secondSquared'
+
+		the conversion factor for watt-hour is 3600
+		the exponent of kilogram is 1
+		the exponent of meter is 2
+		the exponent of second is -2
+		all other exponents are zero
+
+		Every member of a unit group containing watt-hour must be a multiple of kilogram meterSquared per secondSquared.""" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of second" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfSteradian
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfSteradian> rdf:type owl:DatatypeProperty ;
+                                                                     rdfs:domain [ rdf:type owl:Class ;
+                                                                                   owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                                 <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                               )
+                                                                                 ] ;
+                                                                     rdfs:range xsd:decimal ;
+                                                                     rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                     <http://www.w3.org/2004/02/skos/core#definition> "The exponent of steradian in a product of powers of base units." ;
+                                                                     <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 watt per square meter steradian = 1 x kilogram per secondCubed steradian'
+
+		the conversion factor for watt per square meter steradian is 1
+		the exponent of kilogram is 1
+		the exponent of second is -3
+		the exponent of steradian is -1
+		all other exponents are zero
+
+		Every member of a unit group containing watt per square meter steradian must a multiple of kilogram per secondCubed steradian.""" ;
+                                                                     <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of steradian" ;
+                                                                     <http://www.w3.org/2004/02/skos/core#scopeNote> "Steradian is a measure of solid angle." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/exponentOfUSDollar
+<https://w3id.org/semanticarts/ns/ontology/gist/exponentOfUSDollar> rdf:type owl:DatatypeProperty ;
+                                                                    rdfs:domain [ rdf:type owl:Class ;
+                                                                                  owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup>
+                                                                                                <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                              )
+                                                                                ] ;
+                                                                    rdfs:range xsd:decimal ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The exponent of US Dollar in a product of powers of base units." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#example> """In the equation '1 million dollars per week = 1.65344 x dollar per second'
+
+		the conversion factor for million dollars per week is 1.65344
+		the exponent of US Dollar is 1
+		the exponent of second is -1
+		all other exponents are zero
+
+		Every member of a unit group containing million dollars per week must be a multiple of dollar per second.""" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "exponent of US dollar" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#scopeNote> "The factors for converting from one currency to another change constantly." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/idText
+<https://w3id.org/semanticarts/ns/ontology/gist/idText> rdf:type owl:DatatypeProperty ;
+                                                        rdfs:range xsd:string ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "Relates an individual to a text string that identifies it." ;
+                                                        <http://www.w3.org/2004/02/skos/core#example> "The id text for a car is '4Y1SL65848Z411439'" ,
+                                                                                                      "The id text for the HR department for Company X is H31415" ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "id text" ;
+                                                        <http://www.w3.org/2004/02/skos/core#scopeNote> "A common use case would be for pre-existing internal company identifiers." ,
+                                                                                                        "Often, there will be just one identifying text string. More would be appropriate if the individual had different identifiers, such as employee number and social security number. A good way to model that would be to have functional subproperties of idText, such as departmentNumber." ,
+                                                                                                        "This property is an alternative to using the property isIdentifiedBy in conjunction with instances of the class ID." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/isRecordedAt
+<https://w3id.org/semanticarts/ns/ontology/gist/isRecordedAt> rdf:type owl:DatatypeProperty ;
+                                                              rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/atDateTime> ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "Date that something was posted, not necessarily the date it occurred. Must be after the date of occurrence, but could be before or after the planned date. (Unusual, but I could record today that I expected to be paid last week.)" ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "is recorded at" ;
+                                                              <http://www.w3.org/2004/02/skos/core#scopeNote> "Precision may vary according to context." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/latitude
+<https://w3id.org/semanticarts/ns/ontology/gist/latitude> rdf:type owl:DatatypeProperty ;
+                                                          rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint> ;
+                                                          rdfs:range xsd:double ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "Degrees above or below equator" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "latitude" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/longitude
+<https://w3id.org/semanticarts/ns/ontology/gist/longitude> rdf:type owl:DatatypeProperty ;
+                                                           rdfs:domain <https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint> ;
+                                                           rdfs:range xsd:double ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Degrees from GM" ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "longitude" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/name
+<https://w3id.org/semanticarts/ns/ontology/gist/name> rdf:type owl:DatatypeProperty ;
+                                                      rdfs:range xsd:string ;
+                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "Relates an individual to (one of) its name(s)." ;
+                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "name" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/numericValue
+<https://w3id.org/semanticarts/ns/ontology/gist/numericValue> rdf:type owl:DatatypeProperty ;
+                                                              rdfs:range [ rdf:type rdfs:Datatype ;
+                                                                           owl:unionOf ( xsd:byte
+                                                                                         xsd:decimal
+                                                                                         xsd:double
+                                                                                         xsd:float
+                                                                                         xsd:int
+                                                                                         xsd:integer
+                                                                                         xsd:long
+                                                                                         xsd:negativeInteger
+                                                                                         xsd:nonNegativeInteger
+                                                                                         xsd:nonPositiveInteger
+                                                                                         xsd:positiveInteger
+                                                                                         xsd:short
+                                                                                         xsd:unsignedByte
+                                                                                         xsd:unsignedInt
+                                                                                         xsd:unsignedLong
+                                                                                         xsd:unsignedShort
+                                                                                         owl:rational
+                                                                                         owl:real
+                                                                                       )
+                                                                         ] ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "The actual value of a magnitude." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "numeric value" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDate
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDate> rdf:type owl:DatatypeProperty ;
+                                                                rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDateTime> ;
+                                                                rdfs:range xsd:dateTime ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "The date that something is or was planned to end, with precision of one day." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T00:00:00-6:00'^^xsd:dateTime" ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "planned end date" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for anything with a planned end date, such as when a lease will expire, when an offer is no longer available, etc. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDateTime> rdf:type owl:DatatypeProperty ;
+                                                                    rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/endDateTime> ;
+                                                                    rdfs:range xsd:dateTime ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The date that something is or was planned to end, with no implied precision." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "planned end date time" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#scopeNote> "This is an abstraction over the various precisions of planned end time, and is not expected to be asserted directly. Values of predicates with different precisions can be compared since they are all formally xsd:datetimes." ,
+                                                                                                                    "This property, unlike gist:actualEndDateTime, does not have a subproperty for microsecond precision, because planned times typically are not expressed at that level of granularity. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedEndMinute
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedEndMinute> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDateTime> ;
+                                                                  rdfs:range xsd:dateTime ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The date and time that something is or was planned to end, with precision of one minute." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T08:32:00-6:00'^^xsd:dateTime" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "planned end minute" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things like meetings and time card entries, where the hour and minute are important. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision.Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedEndYear
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedEndYear> rdf:type owl:DatatypeProperty ;
+                                                                rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDateTime> ;
+                                                                rdfs:range xsd:dateTime ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "The date that something is or was planned to end, with precision of one year." ;
+                                                                <http://www.w3.org/2004/02/skos/core#example> "'2021-01-01T00:00:00-6:00'^^xsd:dateTime" ,
+                                                                                                              "The automobile manufacturer announced that it will stop producing gas-powered vehicles in 2035." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "planned end year" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for anything with a planned end date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDate
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDate> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime> ;
+                                                                  rdfs:range xsd:dateTime ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The date that something is or was planned to start, with precision of one day." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T00:00:00-6:00'^^xsd:dateTime" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "planned start date" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for anything with a planned start date, such as when a lease will start, when a configuration becomes available, etc. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime> rdf:type owl:DatatypeProperty ;
+                                                                      rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/startDateTime> ;
+                                                                      rdfs:range xsd:dateTime ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "The date and time that something is or was planned to start, with no implied precision." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "planned start date time" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#scopeNote> "This is an abstraction over the various precisions of planned start time, and is not expected to be asserted directly. Values of predicates with different precisions can be compared since they are all formally xsd:datetimes." ,
+                                                                                                                      "This property, unlike gist:actualStartDateTime, does not have a subproperty for microsecond precision, because planned times typically are not expressed at that level of granularity. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedStartMinute
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedStartMinute> rdf:type owl:DatatypeProperty ;
+                                                                    rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime> ;
+                                                                    rdfs:range xsd:dateTime ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The date and time that something is or was planned to start, with precision of one minute." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#example> "'2021-06-01T08:32:00-6:00'^^xsd:dateTime" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "planned start minute" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for things like meetings and time card entries, where the hour and minute are important. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/plannedStartYear
+<https://w3id.org/semanticarts/ns/ontology/gist/plannedStartYear> rdf:type owl:DatatypeProperty ;
+                                                                  rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime> ;
+                                                                  rdfs:range xsd:dateTime ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The date that something is or was planned to start, with precision of one year." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> "'2021-01-01T00:00:00-6:00'^^xsd:dateTime" ,
+                                                                                                                "The automobile manufacturer announced that its full line-up will include only electric cars starting in 2035." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "planned start year" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for anything with a planned start date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/sequence
+<https://w3id.org/semanticarts/ns/ontology/gist/sequence> rdf:type owl:DatatypeProperty ;
+                                                          rdfs:range xsd:integer ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "For ordering ordered lists." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "sequence" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/startDateTime
+<https://w3id.org/semanticarts/ns/ontology/gist/startDateTime> rdf:type owl:DatatypeProperty ;
+                                                               rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/atDateTime> ;
+                                                               rdfs:range xsd:dateTime ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "The date and time that something starts." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "start date time" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "This property is neutral along two dimensions: precision (e.g., day, second, millisecond) and actual vs. planned. As such, it will generally not be asserted directly except in special cases (e.g., for time intervals)." ,
+                                                                                                               "Values of predicates with different precisions can be compared since they are all formally xsd:datetimes." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/symbol
+<https://w3id.org/semanticarts/ns/ontology/gist/symbol> rdf:type owl:DatatypeProperty ;
+                                                        rdfs:range xsd:string ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "A symbol for something using only ASCII characters." ;
+                                                        <http://www.w3.org/2004/02/skos/core#example> "The ASCII symbol for square meter is m^2." ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "symbol" ;
+                                                        <https://w3id.org/semanticarts/ns/ontology/gist/domainIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/uniqueText
+<https://w3id.org/semanticarts/ns/ontology/gist/uniqueText> rdf:type owl:DatatypeProperty ;
+                                                            rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/containedText> ;
+                                                            rdf:type owl:FunctionalProperty ;
+                                                            rdfs:range xsd:string ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "The unique string value of some content object, to be used when there is no possibility of having more than one value." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "The unique string for a vehicle identification number." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "unique text" ;
+                                                            <http://www.w3.org/2004/02/skos/core#scopeNote> "Note that the uniqueness only goes in one direction: a product catalog number might also be an employee ID." ;
+                                                            <https://w3id.org/semanticarts/ns/ontology/gist/domainIncludes> <https://w3id.org/semanticarts/ns/ontology/gist/ID> ,
+                                                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/MediaType> ,
+                                                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Tag> ,
+                                                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Text> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/at_issue
+:at_issue rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/containedText> ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-29T22:09:03Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/author_string
+:author_string rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :content_metadata ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-30T04:43:25Z"^^xsd:dateTime ;
+               <http://www.w3.org/2004/02/skos/core#definition> "A string with the authors of a book, article, or other content. Often more than one author delimited by a semi-colon." .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/content_metadata
+:content_metadata rdf:type owl:DatatypeProperty ;
+                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                  dct:created "2025-01-30T04:45:57Z"^^xsd:dateTime ;
+                  <http://www.w3.org/2004/02/skos/core#definition> "Text strings that hold metadata for content such as books, journal articles, web pages, etc. These strings are for the initial metadata before post processing turns them into objects and object properties or datatypes such as xsd:dateTime" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/first_name
+:first_name rdf:type owl:DatatypeProperty ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-29T00:49:23Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/last_name
+:last_name rdf:type owl:DatatypeProperty ;
+           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+           dct:created "2025-01-29T00:49:13Z"^^xsd:dateTime ;
+           <http://www.w3.org/2004/02/skos/core#definition> "Last name for a Person. This is the only mandatory name property." .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/middle_name
+:middle_name rdf:type owl:DatatypeProperty ;
+             dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+             dct:created "2025-01-29T00:49:33Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/publication_date
+:publication_date rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf :content_metadata ;
+                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                  dct:created "2025-01-30T04:48:54Z"^^xsd:dateTime ;
+                  <http://www.w3.org/2004/02/skos/core#definition> "The datatype here is a literal (string) rather than xsd:dateTime because this is for dates scraped from web sites or other metadata." .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/summary
+:summary rdf:type owl:DatatypeProperty ;
+         rdfs:subPropertyOf <https://w3id.org/semanticarts/ns/ontology/gist/containedText> ;
+         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+         dct:created "2025-01-29T22:07:46Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/text
+:text rdf:type owl:DatatypeProperty ;
+      rdfs:subPropertyOf :content_metadata ;
+      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+      dct:created "2025-01-30T05:14:56Z"^^xsd:dateTime .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Account
+<https://w3id.org/semanticarts/ns/ontology/gist/Account> rdf:type owl:Class ;
+                                                         owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Agreement>
+                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                      owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                                      owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                                [ rdf:type owl:Restriction ;
+                                                                                                                                                  owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                                  owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_financial_balance>
+                                                                                                                                                ]
+                                                                                                                                              ) ;
+                                                                                                                           rdf:type owl:Class
+                                                                                                                         ]
+                                                                                                    ]
+                                                                                                  ) ;
+                                                                               rdf:type owl:Class
+                                                                             ] ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "An agreement having a balance, as in a bank account, or credit card account, or Accounts Receivable account." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "Account" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Address
+<https://w3id.org/semanticarts/ns/ontology/gist/Address> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Content> ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "A reference to a place (real or virtual) that can be located by some routing algorithm and where messages or things can be sent to or received from." ;
+                                                         <http://www.w3.org/2004/02/skos/core#example> "A PO Box, a URL to a PDF file." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "Address" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/AddressUsageType
+<https://w3id.org/semanticarts/ns/ontology/gist/AddressUsageType> rdf:type owl:Class ;
+                                                                  rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "A category indicating the context or manner in which an address may be used." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> "Billing, business, personal, postal, residence." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "Address Usage Type" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "If you are using temporal relations involving addresses, this category should be used to qualify the temporal relation rather than the address itself, since the same address may have different uses in different contexts, by different people and organizations, or at different times." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Agreement
+<https://w3id.org/semanticarts/ns/ontology/gist/Agreement> rdf:type owl:Class ;
+                                                           owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Commitment>
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasParty> ;
+                                                                                                        owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                             owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                         )
+                                                                                                                           ]
+                                                                                                      ]
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isDirectPartOf>
+                                                                                                                       ] ;
+                                                                                                        owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
+                                                                                                        owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/Obligation>
+                                                                                                      ]
+                                                                                                    ) ;
+                                                                                 rdf:type owl:Class
+                                                                               ] ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Something which two or more People or Organizations mutually commit to do." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Agreement" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Artifact
+<https://w3id.org/semanticarts/ns/ontology/gist/Artifact> rdf:type owl:Class ;
+                                                          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGoal> ;
+                                                                            owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Function>
+                                                                          ] ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "An intentional, person-made thing, which could be physical or content" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Artifact" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Aspect
+<https://w3id.org/semanticarts/ns/ontology/gist/Aspect> rdf:type owl:Class ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "A measurable characteristic such as length, weight, cost, cycle time, or defect rate." ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "Aspect" ;
+                                                        <http://www.w3.org/2004/02/skos/core#scopeNote> "Every aspect should be related to a broader aspect or to a unit group. For example, angle of incidence should be related to the broader concept of angle, which in turn is related to a unit group." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Behavior
+<https://w3id.org/semanticarts/ns/ontology/gist/Behavior> rdf:type owl:Class ;
+                                                          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A way of categorizing events.  E.g., differentiating drilling versus cutting." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Behavior" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Building
+<https://w3id.org/semanticarts/ns/ontology/gist/Building> rdf:type owl:Class ;
+                                                          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Artifact> ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/Landmark> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A relatively permanent man-made structure situated on a plot of land, having a roof and walls, commonly used for dwelling, entertaining, or working." ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "A house, school, store, factory, chicken coop." ,
+                                                                                                        "Negative examples: houseboats (not built on land), caves (not man-made), food trucks and RVs (not permanently situated)." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Building" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "User discretion can be applied to edge cases: e.g., is a traditional yurt 'relatively permanently situated' although it is portable and has a tent-like construction?" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/BundledCatalogItem
+<https://w3id.org/semanticarts/ns/ontology/gist/BundledCatalogItem> rdf:type owl:Class ;
+                                                                    owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem>
+                                                                                                               [ rdf:type owl:Restriction ;
+                                                                                                                 owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isDirectPartOf>
+                                                                                                                                ] ;
+                                                                                                                 owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem>
+                                                                                                               ]
+                                                                                                             ) ;
+                                                                                          rdf:type owl:Class
+                                                                                        ] ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "Any combination of descriptions of things offered together.  Could be a kit (several parts offered together), but could also be a product plus a warranty." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "Bundled Catalog Item" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem
+<https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem> rdf:type owl:Class ;
+                                                             rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Specification> ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "A description of a product or service to be delivered, given in a sufficient level of detail that a receiver could determine whether delivery constituted discharge of the obligation to deliver." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Catalog Item" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "In short, an unambiguous characterization of what it is that a potential buyer is paying for." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Category
+<https://w3id.org/semanticarts/ns/ontology/gist/Category> rdf:type owl:Class ;
+                                                          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isAllocatedBy> ;
+                                                                            owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                 owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty>
+                                                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                             )
+                                                                                               ]
+                                                                          ] ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A concept or label used to categorize other instances without specifying any formal semantics. Things that can be thought of as types are often categories." ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "Tags used in folksonomies; formal definitions from other systems." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Category" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "Often a type can be modeled either as an owl:Class or as a gist:Category. Use the latter if you don't care much about the formal structure of the different types, or if there is a whole hierarchy of types that are going to be managed by a group separate from the ontology developers. The formal structure may be defined elsewhere and linked to, if necessary." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Collection
+<https://w3id.org/semanticarts/ns/ontology/gist/Collection> rdf:type owl:Class ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "A grouping of things." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "A jury is a group of people, a financial ledger is a collection of transaction entries; a route is an (ordered) collection of segments." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "Collection" ;
+                                                            <http://www.w3.org/2004/02/skos/core#scopeNote> "Individuals are placed in the collection using the gist:isMemberOf property. Collections typically are created because the members are functionally connected in some way. This definition allows a collection to have zero members." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Commitment
+<https://w3id.org/semanticarts/ns/ontology/gist/Commitment> rdf:type owl:Class ;
+                                                            owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                                                                         owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Requirement>
+                                                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/Restriction>
+                                                                                                                     )
+                                                                                                       ]
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGiver> ;
+                                                                                                         owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                              owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                          )
+                                                                                                                            ]
+                                                                                                       ]
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isCategorizedBy> ;
+                                                                                                         owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/DegreeOfCommitment>
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ] ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "An obligation (possibly unilateral)." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "Commitment" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Component
+<https://w3id.org/semanticarts/ns/ontology/gist/Component> rdf:type owl:Class ;
+                                                           owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Artifact>
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/contributesTo> ;
+                                                                                                        owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/System>
+                                                                                                      ]
+                                                                                                    ) ;
+                                                                                 rdf:type owl:Class
+                                                                               ] ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "A component is an artifact that contributes to a system.  Could be a simple mechanical component, such as the float contributing to the toilet tank maintaining a constant level, or much more complex as in the internet of things." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Component" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ContemporaryEvent
+<https://w3id.org/semanticarts/ns/ontology/gist/ContemporaryEvent> rdf:type owl:Class ;
+                                                                   owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> ;
+                                                                                                                owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                              ]
+                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> ;
+                                                                                                                owl:maxCardinality "0"^^xsd:nonNegativeInteger
+                                                                                                              ]
+                                                                                                            ) ;
+                                                                                         rdf:type owl:Class
+                                                                                       ] ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "An event that has started but has not yet ended." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Contemporary Event" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "When the event actually ends, it will cease being contemporary." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Content
+<https://w3id.org/semanticarts/ns/ontology/gist/Content> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Artifact> ;
+                                                         owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint> ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion> ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "A document, program, image, etc.  (Categories are not content until they are written down.)" ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "Content" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ContentExpression
+<https://w3id.org/semanticarts/ns/ontology/gist/ContentExpression> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Content> ,
+                                                                                   [ rdf:type owl:Restriction ;
+                                                                                     owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isCategorizedBy> ;
+                                                                                     owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/GeneralMediaType>
+                                                                                   ] ,
+                                                                                   [ rdf:type owl:Restriction ;
+                                                                                     owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isExpressedIn> ;
+                                                                                     owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Language>
+                                                                                   ] ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "Intellectual Property reduced to text, audio etc.  If it contains text (written or spoken), it may be in a language." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Content Expression" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ContingentEvent
+<https://w3id.org/semanticarts/ns/ontology/gist/ContingentEvent> rdf:type owl:Class ;
+                                                                 owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                                              owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                                          owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_probability>
+                                                                                                                                                        ]
+                                                                                                                                                      ) ;
+                                                                                                                                   rdf:type owl:Class
+                                                                                                                                 ]
+                                                                                                            ]
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isTriggeredBy> ;
+                                                                                                              owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                            ]
+                                                                                                          ) ;
+                                                                                       rdf:type owl:Class
+                                                                                     ] ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "An event with a probability of happening in the future, and usually dependent upon some other event or condition." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> "Fire insurance is contingent on a particular building burning down" ,
+                                                                                                               "Sell 20 shares of stock in a given company when the price drops below $200/share." ,
+                                                                                                               "The death benefit payout on a life insurance policy following the death of a specific person." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "Contingent Event" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ContingentObligation
+<https://w3id.org/semanticarts/ns/ontology/gist/ContingentObligation> rdf:type owl:Class ;
+                                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Commitment>
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGiver> ;
+                                                                                                                   owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                                        owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                                      <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                                    )
+                                                                                                                                      ]
+                                                                                                                 ]
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isTriggeredBy> ;
+                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                                 ]
+                                                                                                               ) ;
+                                                                                            rdf:type owl:Class
+                                                                                          ] ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "An obligation that is not yet firm.  There is some contingent event, the occurrence of which will cause the obligation to become firm." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Contingent Obligation" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#scopeNote> "A contingent obligation might have a getter counterparty (as in the case of insurance); but it might not (as in the case of an offer)." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Contract
+<https://w3id.org/semanticarts/ns/ontology/gist/Contract> rdf:type owl:Class ;
+                                                          owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Agreement>
+                                                                                                     [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isUnderJurisdictionOf> ;
+                                                                                                       owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization>
+                                                                                                     ]
+                                                                                                   ) ;
+                                                                                rdf:type owl:Class
+                                                                              ] ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "An Agreement which can be enforced by law" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Contract" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ContractTerm
+<https://w3id.org/semanticarts/ns/ontology/gist/ContractTerm> rdf:type owl:Class ;
+                                                              rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Specification> ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "A specification of some aspect of a contract." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "Contract Term" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ControlledVocabulary
+<https://w3id.org/semanticarts/ns/ontology/gist/ControlledVocabulary> rdf:type owl:Class ;
+                                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Collection>
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy> ;
+                                                                                                                   owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                                        owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                                      <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                                    )
+                                                                                                                                      ]
+                                                                                                                 ]
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                                  ] ;
+                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Category>
+                                                                                                                 ]
+                                                                                                               ) ;
+                                                                                            rdf:type owl:Class
+                                                                                          ] ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "A collection of terms approved and managed by some organization or person." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Controlled Vocabulary" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion
+<https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> rdf:type owl:Class ;
+                                                                  owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/GovernedGeoRegion>
+                                                                                                             [ rdf:type owl:Restriction ;
+                                                                                                               owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy> ;
+                                                                                                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                                                               owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/CountryGovernment>
+                                                                                                             ]
+                                                                                                           ) ;
+                                                                                        rdf:type owl:Class
+                                                                                      ] ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "A defined geographical area (or areas) governed by exactly one country government." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "Country Geo-Region" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/CountryGovernment
+<https://w3id.org/semanticarts/ns/ontology/gist/CountryGovernment> rdf:type owl:Class ;
+                                                                   owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization>
+                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy>
+                                                                                                                               ] ;
+                                                                                                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                                                                owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion>
+                                                                                                              ]
+                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy> ;
+                                                                                                                owl:maxQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                                                                                                owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization>
+                                                                                                              ]
+                                                                                                            ) ;
+                                                                                         rdf:type owl:Class
+                                                                                       ] ;
+                                                                   owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/SubCountryGovernment> ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "A Government Organization which asserts both sovereignty (i.e., it is not governed by some other government organization) and governance over an entity generally recognized as a 'country'." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Country Government" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "While a country government may enter into treaties with other country governments, there are no governing relationships among the treaty members." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/DegreeOfCommitment
+<https://w3id.org/semanticarts/ns/ontology/gist/DegreeOfCommitment> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The difficulty of reversing a commitment." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#example> "A car rental typically has a lower degree of commitment than an airfare reservation." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "Degree Of Commitment" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Determination
+<https://w3id.org/semanticarts/ns/ontology/gist/Determination> rdf:type owl:Class ;
+                                                               rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Event> ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "An event whose purpose is to establish a specific result, value, or outcome, usually by research, measuring, evaluating, or calculating." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "Measuring the sulphur content of crude oil. Evaluating a loan application for approval. Estimating the price of gas for the next three months. Determining whether and by how much an interest rate should change. Classifying something." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Determination" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Discipline
+<https://w3id.org/semanticarts/ns/ontology/gist/Discipline> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "An area of study or practice, such as accounting." ;
+                                                            <http://www.w3.org/2004/02/skos/core#example> "Finance, accounting, project management, acoustics, ballistics, etc." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "Discipline" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ElectronicAddress
+<https://w3id.org/semanticarts/ns/ontology/gist/ElectronicAddress> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Address> ;
+                                                                   owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalAddress> ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#altLabel> "Virtual Address" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "An address referring to a locatable virtual place that does not physically exist but is made by software or electronics to appear to do so." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#example> "A path to a file in a file system, a website URL, an IP address, an email address, a mobile or landline telephone number." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Electronic Address" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ElectronicAddressType
+<https://w3id.org/semanticarts/ns/ontology/gist/ElectronicAddressType> rdf:type owl:Class ;
+                                                                       rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                       <http://www.w3.org/2004/02/skos/core#definition> "A category indicating a kind of electronic address. Such a category is usually based on the technology that enables routing to the address referent." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#example> "URL, file system path, email address, mobile telephone number." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "Electronic Address Type" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Equipment
+<https://w3id.org/semanticarts/ns/ontology/gist/Equipment> rdf:type owl:Class ;
+                                                           owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Artifact>
+                                                                                                      <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem>
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isCategorizedBy> ;
+                                                                                                        owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/EquipmentType>
+                                                                                                      ]
+                                                                                                    ) ;
+                                                                                 rdf:type owl:Class
+                                                                               ] ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Tangible property other than land or buildings.  Any kind of equipment, could be machine, router, car etc." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Equipment" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/EquipmentType
+<https://w3id.org/semanticarts/ns/ontology/gist/EquipmentType> rdf:type owl:Class ;
+                                                               rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "Categories of equipment" ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Equipment Type" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Event
+<https://w3id.org/semanticarts/ns/ontology/gist/Event> rdf:type owl:Class ;
+                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Something that occurs over a period of time, often characterized as an activity being carried out by some person, organization, or software application or brought about by natural forces." ;
+                                                       <http://www.w3.org/2004/02/skos/core#editorialNote> "See guidance on removing the term in the next major release at https://github.com/semanticarts/gist/issues/947#issuecomment-1679565100." ;
+                                                       <http://www.w3.org/2004/02/skos/core#example> "A transaction, conference, baseball game, earthquake." ;
+                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "Event" ;
+                                                       <http://www.w3.org/2004/02/skos/core#scopeNote> "An event does not necessarily have either planned or actual start or end datetimes. For example, a conference can be in the planning phase without any dates selected, but is nevertheless an (unscheduled) event. The subclasses of Event state particular restrictions on planned and actual start and end dates." ,
+                                                                                                       "An event occurs during a time interval, which is distinct from the event." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/EventSpecification
+<https://w3id.org/semanticarts/ns/ontology/gist/EventSpecification> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Specification> ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "A characterization of an event that might happen." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#example> "An insurance company defines the characteristics of a weather event that must be satisfied for it to qualify as a hail storm covered in its homeowner's policy. Defaulting on a loan." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "Event Specification" ;
+                                                                    <http://www.w3.org/2004/02/skos/core#scopeNote> "This concept is useful for risk assessment and insurance policies." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/FormattedContent
+<https://w3id.org/semanticarts/ns/ontology/gist/FormattedContent> rdf:type owl:Class ;
+                                                                  owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/ContentExpression>
+                                                                                                             [ rdf:type owl:Restriction ;
+                                                                                                               owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isExpressedIn> ;
+                                                                                                               owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/MediaType>
+                                                                                                             ]
+                                                                                                           ) ;
+                                                                                        rdf:type owl:Class
+                                                                                      ] ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "Content which is in a particular format. (E.g., HTML, PDF, JPG.)" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "Formatted Content" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Function
+<https://w3id.org/semanticarts/ns/ontology/gist/Function> rdf:type owl:Class ;
+                                                          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A function is what a specific made item is intended to do.  For instance: transmit electricity, provide ballast, control ambient temperature." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Function" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GeneralMediaType
+<https://w3id.org/semanticarts/ns/ontology/gist/GeneralMediaType> rdf:type owl:Class ;
+                                                                  rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "The real-world media type for content." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> "Audio, still image, video, textual, physical (e.g., a statue), or performance (i.e. a play).  Or it could be oil or pastel for a painting." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "General Media Type" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint
+<https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint> rdf:type owl:Class ;
+                                                          owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                                       owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                                   owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_altitude>
+                                                                                                                                                 ]
+                                                                                                                                               ) ;
+                                                                                                                            rdf:type owl:Class
+                                                                                                                          ]
+                                                                                                     ]
+                                                                                                     [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/latitude> ;
+                                                                                                       owl:someValuesFrom xsd:double
+                                                                                                     ]
+                                                                                                     [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/longitude> ;
+                                                                                                       owl:someValuesFrom xsd:double
+                                                                                                     ]
+                                                                                                   ) ;
+                                                                                rdf:type owl:Class
+                                                                              ] ;
+                                                          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                          owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Language> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "An individual point on the Earth's surface, identified by latitude, longitude and altitude. If altitude is missing, it is assumed to be at the Earth's surface.  However, altitude is measured from sea level.  these points are to the WGS-84 coordinate system using the GPS decimal lat/long" ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Geo Point" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "Assume coordinate system used by Google (WGS 84 Web Mercator)." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion
+<https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion> rdf:type owl:Class ;
+                                                           rdfs:subClassOf [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Place>
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                                    owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                                owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_area>
+                                                                                                                                              ]
+                                                                                                                                            ) ;
+                                                                                                                         rdf:type owl:Class
+                                                                                                                       ]
+                                                                                                  ]
+                                                                                                ) ;
+                                                                             rdf:type owl:Class
+                                                                           ] ;
+                                                           owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Language> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Template> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "A bounded region (or set of regions) on the surface of the Earth." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "The bounded shape that defines the region occupied by Crater Lake; the bounded area known as the contiguous USA." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Geo Region" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "A GeoRegion could be non-contiguous; e.g. the region governed by the USA is the region governed by the lower 48 states plus that of Alaska and Hawaii.  Child classes in lower ontologies can make this distinction." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GeoRoute
+<https://w3id.org/semanticarts/ns/ontology/gist/GeoRoute> rdf:type owl:Class ;
+                                                          owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/OrderedCollection>
+                                                                                                     <https://w3id.org/semanticarts/ns/ontology/gist/Place>
+                                                                                                     [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isDirectPartOf>
+                                                                                                                      ] ;
+                                                                                                       owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/GeoSegment>
+                                                                                                     ]
+                                                                                                   ) ;
+                                                                                rdf:type owl:Class
+                                                                              ] ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "An ordered set of GeoPoints that defines a path from starting point to ending point." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Geo Route" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GeoSegment
+<https://w3id.org/semanticarts/ns/ontology/gist/GeoSegment> rdf:type owl:Class ;
+                                                            owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/comesFromPlace> ;
+                                                                                                         owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                                                         owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint>
+                                                                                                       ]
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/goesToPlace> ;
+                                                                                                         owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                                                         owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint>
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ] ;
+                                                            rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "A single portion of a GeoRegion which has been divided (i.e., segmented)." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "Geo Segment" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GeoVolume
+<https://w3id.org/semanticarts/ns/ontology/gist/GeoVolume> rdf:type owl:Class ;
+                                                           owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                                        owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                                    owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_volume>
+                                                                                                                                                  ]
+                                                                                                                                                ) ;
+                                                                                                                             rdf:type owl:Class
+                                                                                                                           ]
+                                                                                                      ]
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn>
+                                                                                                                       ] ;
+                                                                                                        owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/GeoPoint>
+                                                                                                      ]
+                                                                                                    ) ;
+                                                                                 rdf:type owl:Class
+                                                                               ] ;
+                                                           rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "A three-dimensional space on or near the surface of the Earth, such as an oil reservoir, the body of a lake, or an airspace." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Geo Volume" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GovernedGeoRegion
+<https://w3id.org/semanticarts/ns/ontology/gist/GovernedGeoRegion> rdf:type owl:Class ;
+                                                                   owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion>
+                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy> ;
+                                                                                                                owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                                                                owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization>
+                                                                                                              ]
+                                                                                                            ) ;
+                                                                                         rdf:type owl:Class
+                                                                                       ] ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "A defined geographic area or areas governed by at least one government organization." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Governed Geo-Region" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "Geographic regions do not need not be physically contiguous in order to constitute a governed geo-region; e.g., Alaska and Hawaii." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization
+<https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization> rdf:type owl:Class ;
+                                                                        rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ;
+                                                                        owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/IntergovernmentalOrganization> ;
+                                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                        <http://www.w3.org/2004/02/skos/core#definition> "An organization which exercises political and/or regulatory authority over a political unit, people, geo-region, etc., as well as performing certain functions for this unit or body. Differs from a corporation in that it cannot be owned." ;
+                                                                        <http://www.w3.org/2004/02/skos/core#example> "The State of Washington Office of Financial Management; the Food and Drug Administration; the Scottish Parliament." ;
+                                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "Government Organization" ;
+                                                                        <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes administrative, regulatory, and enforcement organizations created or sanctioned by Country or SubCountry Governments." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/HistoricalEvent
+<https://w3id.org/semanticarts/ns/ontology/gist/HistoricalEvent> rdf:type owl:Class ;
+                                                                 owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/actualEndDateTime> ;
+                                                                                                              owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                            ]
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/actualStartDateTime> ;
+                                                                                                              owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                            ]
+                                                                                                          ) ;
+                                                                                       rdf:type owl:Class
+                                                                                     ] ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "An event which occurred in time, with an actual end earlier than the present moment." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "Historical Event" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ID
+<https://w3id.org/semanticarts/ns/ontology/gist/ID> rdf:type owl:Class ;
+                                                    owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Content>
+                                                                                               [ rdf:type owl:Restriction ;
+                                                                                                 owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isAllocatedBy> ;
+                                                                                                 owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                      owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty>
+                                                                                                                                    <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                    <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                  )
+                                                                                                                    ]
+                                                                                               ]
+                                                                                               [ rdf:type owl:Restriction ;
+                                                                                                 owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/uniqueText> ;
+                                                                                                 owl:someValuesFrom xsd:string
+                                                                                               ]
+                                                                                             ) ;
+                                                                          rdf:type owl:Class
+                                                                        ] ;
+                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "Content that is used to uniquely identify something or someone." ;
+                                                    <http://www.w3.org/2004/02/skos/core#example> "SSN for a person; serial number for a product; employee ID." ;
+                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "ID" ;
+                                                    <http://www.w3.org/2004/02/skos/core#scopeNote> "This is used in conjunction with gist:isIdentifiedBy" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty
+<https://w3id.org/semanticarts/ns/ontology/gist/IntellectualProperty> rdf:type owl:Class ;
+                                                                      rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Artifact> ;
+                                                                      owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ,
+                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ,
+                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "A work, invention or concept, independent of its being expressed in text, audio, video, image, or live performance.  IP can also be tacit knowledge, know-how, or skill. Also includes Brands." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#example> "The Old Man and The Sea; the Page Rank algorithm; Coca Cola" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Intellectual Property" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#scopeNote> "For literature this could be called the ?Work?, except that ?work? is a highly overloaded term (expenditure of energy, resource consumption, art).  Often the first expression precedes our recognition of the IP, but subsequent expressions are known to be derivatives of the IP, even if they are expression-to-expression translations (or copies)." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Intention
+<https://w3id.org/semanticarts/ns/ontology/gist/Intention> rdf:type owl:Class ;
+                                                           owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Goal, desire, aspiration. This is the \"teleologic\" aspect of the system that indicates things are done with a purpose." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Intention" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/IntergovernmentalOrganization
+<https://w3id.org/semanticarts/ns/ontology/gist/IntergovernmentalOrganization> rdf:type owl:Class ;
+                                                                               owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                                            owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                                           ] ;
+                                                                                                                            owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
+                                                                                                                            owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization>
+                                                                                                                          ]
+                                                                                                                        ) ;
+                                                                                                     rdf:type owl:Class
+                                                                                                   ] ;
+                                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                               <http://www.w3.org/2004/02/skos/core#definition> "An organization whose members are government organizations. This can comprise regional, municipal, state/province, or national level entities." ;
+                                                                               <http://www.w3.org/2004/02/skos/core#example> "The United Nations, the European Union, the MTA (Metropolitan Transit Authority)" ;
+                                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Intergovernmental Organization" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Landmark
+<https://w3id.org/semanticarts/ns/ontology/gist/Landmark> rdf:type owl:Class ;
+                                                          owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem>
+                                                                                                     [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasPhysicalLocation> ;
+                                                                                                       owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                            owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion>
+                                                                                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/GeoVolume>
+                                                                                                                                        )
+                                                                                                                          ]
+                                                                                                     ]
+                                                                                                   ) ;
+                                                                                rdf:type owl:Class
+                                                                              ] ;
+                                                          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Place> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "Something permanently attached to the Earth." ;
+                                                          <http://www.w3.org/2004/02/skos/core#editorialNote> "See guidance on removing the term in the next major release at https://github.com/semanticarts/gist/issues/947#issuecomment-1679566885." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Landmark" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Language
+<https://w3id.org/semanticarts/ns/ontology/gist/Language> rdf:type owl:Class ;
+                                                          owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A recognized, organized set of symbols and grammar." ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "Natural languages such as English and Spanish; computer languages such as OWL, Python, and XML." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Language" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/LivingThing
+<https://w3id.org/semanticarts/ns/ontology/gist/LivingThing> rdf:type owl:Class ;
+                                                             owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem>
+                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasBiologicalParent> ;
+                                                                                                          owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/LivingThing>
+                                                                                                        ]
+                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/birthDate> ;
+                                                                                                          owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                        ]
+                                                                                                      ) ;
+                                                                                   rdf:type owl:Class
+                                                                                 ] ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "Something that is currently, or at some point in time was, alive." ;
+                                                             <http://www.w3.org/2004/02/skos/core#example> "A cat, a mushroom, a tree." ,
+                                                                                                           "Negative examples: fictional life forms such as unicorns or Mickey Mouse." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Living Thing" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "Not all life forms have exactly two parents, so the restriction only specifies a minimum of one." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Magnitude
+<https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> rdf:type owl:Class ;
+                                                           owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                        owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Aspect>
+                                                                                                      ]
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasUnitOfMeasure> ;
+                                                                                                        owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                                      ]
+                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/numericValue> ;
+                                                                                                        owl:someValuesFrom rdfs:Literal
+                                                                                                      ]
+                                                                                                    ) ;
+                                                                                 rdf:type owl:Class
+                                                                               ] ;
+                                                           owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           rdfs:seeAlso <https://w3id.org/semanticarts/ns/ontology/gist/hasAccuracy> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "The amount of a measurable characteristic (aspect)." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "A model of car could have a wheelbase of 113.2 inches. In this example, the aspect is wheelbase, the unit of measure is inch, and the numeric value is 113.2." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Magnitude" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "An accuracy can be assigned to a magnitude using the property has accuracy." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/MediaType
+<https://w3id.org/semanticarts/ns/ontology/gist/MediaType> rdf:type owl:Class ;
+                                                           rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ,
+                                                                           [ rdf:type owl:Restriction ;
+                                                                             owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/uniqueText> ;
+                                                                             owl:someValuesFrom xsd:string
+                                                                           ] ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           rdfs:seeAlso <https://www.iana.org/assignments/media-types/media-types.xhtml> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "A digitized type that computer applications can recognize." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "application/sparql-results+xml" ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Media Type" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "The unique text for an IANA media type is the concatenation of the 'Type name', a slash '/', and the 'Subtype name' as provided on the page displayed when you resolve the URI of the media type." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Medium
+<https://w3id.org/semanticarts/ns/ontology/gist/Medium> rdf:type owl:Class ;
+                                                        rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "A physicality on which a work could be implemented or exposed. E.g., paper, clay, or a computer monitor." ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "Medium" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Message
+<https://w3id.org/semanticarts/ns/ontology/gist/Message> rdf:type owl:Class ;
+                                                         owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/ContentExpression>
+                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                      owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/comesFromAgent> ;
+                                                                                                      owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                           owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                         <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                       )
+                                                                                                                         ]
+                                                                                                    ]
+                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                      owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/goesToAgent> ;
+                                                                                                      owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                           owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                         <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                       )
+                                                                                                                         ]
+                                                                                                    ]
+                                                                                                  ) ;
+                                                                               rdf:type owl:Class
+                                                                             ] ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "A specific instance of content sent from a sender to at least one other recipient." ;
+                                                         <http://www.w3.org/2004/02/skos/core#example> "An email message, a phone call, a voice message, or a Web Service message." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "Message" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Network
+<https://w3id.org/semanticarts/ns/ontology/gist/Network> rdf:type owl:Class ;
+                                                         owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Artifact>
+                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                      owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                     ] ;
+                                                                                                      owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                           owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/NetworkLink>
+                                                                                                                                         <https://w3id.org/semanticarts/ns/ontology/gist/NetworkNode>
+                                                                                                                                       )
+                                                                                                                         ]
+                                                                                                    ]
+                                                                                                  ) ;
+                                                                               rdf:type owl:Class
+                                                                             ] ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "A network is a set of nodes connected by links." ;
+                                                         <http://www.w3.org/2004/02/skos/core#example> "A physical network could include connected computers or routers, whereas a social network would consist of related Person or Organization instances." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "Network" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/NetworkLink
+<https://w3id.org/semanticarts/ns/ontology/gist/NetworkLink> rdf:type owl:Class ;
+                                                             owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> ;
+                                                                                                          owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Network>
+                                                                                                        ]
+                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/links> ;
+                                                                                                          owl:allValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/NetworkNode>
+                                                                                                        ]
+                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/links> ;
+                                                                                                          owl:qualifiedCardinality "2"^^xsd:nonNegativeInteger ;
+                                                                                                          owl:onClass <https://w3id.org/semanticarts/ns/ontology/gist/NetworkNode>
+                                                                                                        ]
+                                                                                                      ) ;
+                                                                                   rdf:type owl:Class
+                                                                                 ] ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "An abstract representation of the connection between two or more nodes in a network." ;
+                                                             <http://www.w3.org/2004/02/skos/core#example> "A network link may be physical, such as pipes, wired or wireless networks, but may also be a link in a non-physical network, such as organizational structures or social networks." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Network Link" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "Each NetworkLink is connected to a NetworkNode via the property 'gist:links' or one of its subproperties." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/NetworkNode
+<https://w3id.org/semanticarts/ns/ontology/gist/NetworkNode> rdf:type owl:Class ;
+                                                             rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                               owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> ;
+                                                                               owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Network>
+                                                                             ] ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "A node in a network." ;
+                                                             <http://www.w3.org/2004/02/skos/core#example> "A person is a node in a social network; a valve is a node in a network of pipes." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Network Node" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Obligation
+<https://w3id.org/semanticarts/ns/ontology/gist/Obligation> rdf:type owl:Class ;
+                                                            owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Commitment>
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGiver> ;
+                                                                                                         owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                              owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                          )
+                                                                                                                            ]
+                                                                                                       ]
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasRecipient> ;
+                                                                                                         owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                              owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                            <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                          )
+                                                                                                                            ]
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ] ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "A future commitment from one organization or person to another. Contracts are sets of obligations to do or forbear, or to indemnify or warrant." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "Obligation" ;
+                                                            <http://www.w3.org/2004/02/skos/core#scopeNote> "Obligations will often be governed by some Agreement or Offer." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Offer
+<https://w3id.org/semanticarts/ns/ontology/gist/Offer> rdf:type owl:Class ;
+                                                       owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/ContingentObligation>
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGiver> ;
+                                                                                                    owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                         owl:unionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Organization>
+                                                                                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                                                     )
+                                                                                                                       ]
+                                                                                                  ]
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                                    owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                                owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_monetary_value>
+                                                                                                                                              ]
+                                                                                                                                            ) ;
+                                                                                                                         rdf:type owl:Class
+                                                                                                                       ]
+                                                                                                  ]
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/offers> ;
+                                                                                                    owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem>
+                                                                                                  ]
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/plannedEndDateTime> ;
+                                                                                                    owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                  ]
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime> ;
+                                                                                                    owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                  ]
+                                                                                                ) ;
+                                                                             rdf:type owl:Class
+                                                                           ] ;
+                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "A commitment to buy or sell a described or identified part or service." ;
+                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "Offer" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/OrderedCollection
+<https://w3id.org/semanticarts/ns/ontology/gist/OrderedCollection> rdf:type owl:Class ;
+                                                                   owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Collection>
+                                                                                                              [ rdf:type owl:Class ;
+                                                                                                                owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isFirstMemberOf>
+                                                                                                                                               ] ;
+                                                                                                                                owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember>
+                                                                                                                              ]
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                                               ] ;
+                                                                                                                                owl:cardinality "0"^^xsd:nonNegativeInteger
+                                                                                                                              ]
+                                                                                                                            )
+                                                                                                              ]
+                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                               ] ;
+                                                                                                                owl:allValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember>
+                                                                                                              ]
+                                                                                                            ) ;
+                                                                                         rdf:type owl:Class
+                                                                                       ] ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "A collection in which the members are sequentially ordered. All members of an OrderedCollection are OrderedMembers." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Ordered Collection" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes collections in which members occupy the same position in a 'tie.'" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember
+<https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember> rdf:type owl:Class ;
+                                                               owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                                                                            owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/precedesDirectly> ;
+                                                                                                                            owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember>
+                                                                                                                          ]
+                                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                                            owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/precedesDirectly>
+                                                                                                                                           ] ;
+                                                                                                                            owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/OrderedMember>
+                                                                                                                          ]
+                                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/sequence> ;
+                                                                                                                            owl:someValuesFrom xsd:integer
+                                                                                                                          ]
+                                                                                                                        )
+                                                                                                          ]
+                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/providesOrderFor> ;
+                                                                                                            owl:someValuesFrom owl:Thing
+                                                                                                          ]
+                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> ;
+                                                                                                            owl:allValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/OrderedCollection>
+                                                                                                          ]
+                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> ;
+                                                                                                            owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                          ]
+                                                                                                        ) ;
+                                                                                     rdf:type owl:Class
+                                                                                   ] ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "A member of an ordered collection serving as a proxy for a real world item, which can appear in different orders in different collections. The ordered member appears in exactly one ordered collection." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "A person may rank 12th in the Boston Marathon but 29th in the New York City Marathon." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Ordered Member" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "An ordered member points to the real world item via the providesOrderFor property. Ordering information is represented either as a number in a sequence, or by preceding or following another ordered member." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Organization
+<https://w3id.org/semanticarts/ns/ontology/gist/Organization> rdf:type owl:Class ;
+                                                              rdfs:subClassOf :Agent ;
+                                                              owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> ,
+                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> ,
+                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/SchemaMetaData> ,
+                                                                               <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "A generic organization that can be formal or informal, legal or non-legal. It can have members, or not." ;
+                                                              <http://www.w3.org/2004/02/skos/core#example> "Legal entities like companies; non-legal entities like clubs, committees, or departments." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "Organization" ;
+                                                              <http://www.w3.org/2004/02/skos/core#scopeNote> "There are a plethora of different kinds of organizations that differ along many facets, including members, structure, purpose, legal vs. non-legal, etc." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Permission
+<https://w3id.org/semanticarts/ns/ontology/gist/Permission> rdf:type owl:Class ;
+                                                            owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Intention>
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/allows> ;
+                                                                                                         owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Behavior>
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ] ;
+                                                            rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "A description of things one is permitted to do. This could be broad, such as free speech, but more often is very specific, such as the right of egress through a particular property." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "Permission" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Person
+<https://w3id.org/semanticarts/ns/ontology/gist/Person> rdf:type owl:Class ;
+                                                        owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/LivingThing>
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasBiologicalParent> ;
+                                                                                                     owl:allValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Person>
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ] ;
+                                                        rdfs:subClassOf :Agent ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        rdfs:label "Person" ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "A human being that may or may not still be alive." ;
+                                                        <http://www.w3.org/2004/02/skos/core#example> "Negative example:fictional characters." ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "Individual" ;
+                                                        :funding :Advocacy_Organization ;
+                                                        :money :Foundation .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/PhysicalActionType
+<https://w3id.org/semanticarts/ns/ontology/gist/PhysicalActionType> rdf:type owl:Class ;
+                                                                    rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                                    rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The effects to be realized in the real world, such as lifting a garage door, turning off a valve, dropping cadmium rods, etc." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "Physical Action Type" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/PhysicalAddress
+<https://w3id.org/semanticarts/ns/ontology/gist/PhysicalAddress> rdf:type owl:Class ;
+                                                                 owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Address>
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/refersTo> ;
+                                                                                                              owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Place>
+                                                                                                            ]
+                                                                                                          ) ;
+                                                                                       rdf:type owl:Class
+                                                                                     ] ;
+                                                                 rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Address> ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "An address that refers to a locatable place within the physical universe." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#example> "A street address, a PO box address." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "Physical Address" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/PhysicalEvent
+<https://w3id.org/semanticarts/ns/ontology/gist/PhysicalEvent> rdf:type owl:Class ;
+                                                               owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/occursIn> ;
+                                                                                                            owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Place>
+                                                                                                          ]
+                                                                                                        ) ;
+                                                                                     rdf:type owl:Class
+                                                                                   ] ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "An event that can be said to have occurred at some place in space." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "A meeting, a car accident." ,
+                                                                                                             "Negative examples: Excludes events that have no meaningful location, such as financial events or project milestones." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Physical Event" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem
+<https://w3id.org/semanticarts/ns/ontology/gist/PhysicalIdentifiableItem> rdf:type owl:Class ;
+                                                                          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                            owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                        owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_mass>
+                                                                                                                                      ]
+                                                                                                                                    ) ;
+                                                                                                                 rdf:type owl:Class
+                                                                                                               ]
+                                                                                          ] ,
+                                                                                          [ rdf:type owl:Restriction ;
+                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                            owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                                      [ rdf:type owl:Restriction ;
+                                                                                                                                        owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                        owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_volume>
+                                                                                                                                      ]
+                                                                                                                                    ) ;
+                                                                                                                 rdf:type owl:Class
+                                                                                                               ]
+                                                                                          ] ,
+                                                                                          [ rdf:type owl:Restriction ;
+                                                                                            owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isMadeUpOf> ;
+                                                                                            owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance>
+                                                                                          ] ;
+                                                                          owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/SchemaMetaData> ,
+                                                                                           <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                          <http://www.w3.org/2004/02/skos/core#definition> "A discrete physical object which, if subdivided, will result in parts that are distinguishable in nature from the whole and in general also from the other parts." ;
+                                                                          <http://www.w3.org/2004/02/skos/core#example> "A computer, book, car." ;
+                                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Physical Identifiable Item" ;
+                                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "This concept generally corresponds to count nouns in English. By contrast, instances of PhysicalSubstance, such as an amount of water, flour, or sand, are mass nouns. PhysicalIdentifiableItems are made up of PhysicalSubstances; e.g., a cake is made up of butter, flour, and sugar; a statue is made of bronze. If you divide a PhysicalSubstance such as an amount of water into parts, you have two amounts of water otherwise indistinguishable from one another; if you divide a PhysicalIdentifiableItem such as a computer into parts, each part is different from the whole." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance
+<https://w3id.org/semanticarts/ns/ontology/gist/PhysicalSubstance> rdf:type owl:Class ;
+                                                                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                                     owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                     owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                               [ rdf:type owl:Restriction ;
+                                                                                                                                 owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                 owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_mass>
+                                                                                                                               ]
+                                                                                                                             ) ;
+                                                                                                          rdf:type owl:Class
+                                                                                                        ]
+                                                                                   ] ,
+                                                                                   [ rdf:type owl:Restriction ;
+                                                                                     owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                     owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                               [ rdf:type owl:Restriction ;
+                                                                                                                                 owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                                 owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_volume>
+                                                                                                                               ]
+                                                                                                                             ) ;
+                                                                                                          rdf:type owl:Class
+                                                                                                        ]
+                                                                                   ] ;
+                                                                   owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                   rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                   <http://www.w3.org/2004/02/skos/core#definition> "An undifferentiated amount of physical material which, when subdivided, results in each part being indistinguishable in nature from the whole and from every other part." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#example> "An amount of water, penicillin, sand, gold: an actual piece of gold, not the concept of gold." ;
+                                                                   <http://www.w3.org/2004/02/skos/core#prefLabel> "Physical Substance" ;
+                                                                   <http://www.w3.org/2004/02/skos/core#scopeNote> "An instance of this class has weight and takes up space. We mean the physical gold in a ring, not the concept of gold that shows up in the periodic table." ,
+                                                                                                                   "This concept generally corresponds to mass nouns in English. By contrast, instances of PhysicalIdentifiableItem, such as a computer, book, or car, are count nouns. PhysicalIdentifiableItems are made up of PhysicalSubstances; e.g., a cake is made up of butter, flour, and sugar; a ring is made of gold. If you divide a PhysicalSubstance such as an amount of water into parts, you have different amounts of water otherwise indistinguishable from one another; if you divide a PhysicalIdentifiableItem such as a computer into parts, each part will be distinguishable from the original whole." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Place
+<https://w3id.org/semanticarts/ns/ontology/gist/Place> rdf:type owl:Class ;
+                                                       rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Union of all the geo classes" ;
+                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "Place" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ProductCategory
+<https://w3id.org/semanticarts/ns/ontology/gist/ProductCategory> rdf:type owl:Class ;
+                                                                 rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Any of many ways of categorizing products, including models, NATO product codes, and the like." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "Product Category" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ProductSpecification
+<https://w3id.org/semanticarts/ns/ontology/gist/ProductSpecification> rdf:type owl:Class ;
+                                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem>
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isCategorizedBy> ;
+                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/ProductCategory>
+                                                                                                                 ]
+                                                                                                               ) ;
+                                                                                            rdf:type owl:Class
+                                                                                          ] ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "Offering something which could be physically warehoused or digitally stored." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Product Specification" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Project
+<https://w3id.org/semanticarts/ns/ontology/gist/Project> rdf:type owl:Class ;
+                                                         owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Task>
+                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                      owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isPartOf>
+                                                                                                                     ] ;
+                                                                                                      owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Task>
+                                                                                                    ]
+                                                                                                  ) ;
+                                                                               rdf:type owl:Class
+                                                                             ] ;
+                                                         rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "A task, usually of longer duration, made up of other tasks." ;
+                                                         <http://www.w3.org/2004/02/skos/core#example> "Designing an insurance product, adding a new feature to a software application, assessing the level of risk for a mortgage application." ;
+                                                         <http://www.w3.org/2004/02/skos/core#prefLabel> "Project" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ReferenceValue
+<https://w3id.org/semanticarts/ns/ontology/gist/ReferenceValue> rdf:type owl:Class ;
+                                                                rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude> ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "A measure that was neither measured nor estimated but set by fiat. For instance, a goal. There is no measurement associated with a reference value." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "Reference Value" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/RenderedContent
+<https://w3id.org/semanticarts/ns/ontology/gist/RenderedContent> rdf:type owl:Class ;
+                                                                 owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/ContentExpression>
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isExpressedIn> ;
+                                                                                                              owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/MediaType>
+                                                                                                            ]
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isRenderedOn> ;
+                                                                                                              owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Medium>
+                                                                                                            ]
+                                                                                                          ) ;
+                                                                                       rdf:type owl:Class
+                                                                                     ] ;
+                                                                 rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Content which has been expressed, either to print, or through speakers, or on a monitor." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "Rendered Content" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Requirement
+<https://w3id.org/semanticarts/ns/ontology/gist/Requirement> rdf:type owl:Class ;
+                                                             rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "The obligation of a person or organization to behave in a certain way (e.g., drive on the right side of the road)." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Requirement" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Restriction
+<https://w3id.org/semanticarts/ns/ontology/gist/Restriction> rdf:type owl:Class ;
+                                                             owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Intention>
+                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                          owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/prevents> ;
+                                                                                                          owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Behavior>
+                                                                                                        ]
+                                                                                                      ) ;
+                                                                                   rdf:type owl:Class
+                                                                                 ] ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "A description of things one is prevented from doing.  Most laws are restrictions." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Restriction" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ScheduledEvent
+<https://w3id.org/semanticarts/ns/ontology/gist/ScheduledEvent> rdf:type owl:Class ;
+                                                                owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                           [ rdf:type owl:Restriction ;
+                                                                                                             owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/plannedStartDateTime> ;
+                                                                                                             owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                                           ]
+                                                                                                         ) ;
+                                                                                      rdf:type owl:Class
+                                                                                    ] ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "An event with a planned start datetime." ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "Scheduled Event" ;
+                                                                <http://www.w3.org/2004/02/skos/core#scopeNote> "If the event already started, but has not yet ended, it is a contemporary event with an actual start datetime. If the event is over, it is a historical event having an actual end datetime. The event always retains its planned start datetime, and thus continues to be a scheduled event." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ScheduledTask
+<https://w3id.org/semanticarts/ns/ontology/gist/ScheduledTask> rdf:type owl:Class ;
+                                                               owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/ScheduledEvent>
+                                                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/Task>
+                                                                                                        ) ;
+                                                                                     rdf:type owl:Class
+                                                                                   ] ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "A task with a planned start datetime." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Scheduled Task" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "If work on the task has already started, but has not yet ended, it will have an actual start datetime. If the task is completed, it will also have an actual end datetime. The task always retains its planned start time, and thus continues to be a scheduled task." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/SchemaMetaData
+<https://w3id.org/semanticarts/ns/ontology/gist/SchemaMetaData> rdf:type owl:Class ;
+                                                                owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                                rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Superclass for all types of metadata, including owl concepts (such as class) and relational (tables, elements) and tool related (queries, R2RML maps etc etc)" ;
+                                                                <http://www.w3.org/2004/02/skos/core#prefLabel> "Schema Meta Data" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/ServiceSpecification
+<https://w3id.org/semanticarts/ns/ontology/gist/ServiceSpecification> rdf:type owl:Class ;
+                                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/CatalogItem>
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isBasedOn>
+                                                                                                                                  ] ;
+                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                                 ]
+                                                                                                               ) ;
+                                                                                            rdf:type owl:Class
+                                                                                          ] ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "A description of something that can be done for a person or organization (which produces some form of an act)." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Service Specification" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Specification
+<https://w3id.org/semanticarts/ns/ontology/gist/Specification> rdf:type owl:Class ;
+                                                               rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "One or more characteristics that specify what it means to be a particular type of thing, such as a material, product, service or event. A specification is sufficiently precise to allow evaluating conformance to the specification." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "The specification of the iPhone 14; hypothetical events covered by a homeowner's insurance policy." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Specification" ;
+                                                               <http://www.w3.org/2004/02/skos/core#scopeNote> "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the TaskTemplate class for specifying the how, such as a plan or process specification." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/SubCountryGovernment
+<https://w3id.org/semanticarts/ns/ontology/gist/SubCountryGovernment> rdf:type owl:Class ;
+                                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/GovernmentOrganization>
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy> ;
+                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/CountryGovernment>
+                                                                                                                 ]
+                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                   owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isGovernedBy>
+                                                                                                                                  ] ;
+                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion>
+                                                                                                                 ]
+                                                                                                               ) ;
+                                                                                            rdf:type owl:Class
+                                                                                          ] ;
+                                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                      <http://www.w3.org/2004/02/skos/core#definition> "A government of a governed geo-region other than a country, which is under the direct or indirect control of a country government." ;
+                                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Sub-Country Government" ;
+                                                                      <http://www.w3.org/2004/02/skos/core#scopeNote> "Across the world, there are a variety of types of subsections of a country and the governments thereof (as well as different terms, like 'province' and 'state', which refer to essentially the same type of thing). We should not automatically assume 'state', 'county', and 'city'.  It is more future-proof just to mint the instances using the generic SubCountryGovernment and, where greater specificity is needed, define categories or subclasses." ,
+                                                                                                                      "Note that the predicate 'governs' is used both for the relationship a government has to a governed geo-region, and for the relationship one government has to the governments of its sub-regions." ,
+                                                                                                                      "This class applies only to organizations governing geo-regions. Regulatory and bureaucratic organizations are members of the more generic GovernmentOrganization class." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/System
+<https://w3id.org/semanticarts/ns/ontology/gist/System> rdf:type owl:Class ;
+                                                        owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Artifact>
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isDirectPartOf>
+                                                                                                                    ] ;
+                                                                                                     owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Component>
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ] ;
+                                                        rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "A system is an artifact with component parts where the parts contribute to the goal of the system" ;
+                                                        <http://www.w3.org/2004/02/skos/core#prefLabel> "System" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Tag
+<https://w3id.org/semanticarts/ns/ontology/gist/Tag> rdf:type owl:Class ;
+                                                     owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Category>
+                                                                                                [ rdf:type owl:Restriction ;
+                                                                                                  owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/containedText> ;
+                                                                                                  owl:someValuesFrom xsd:string
+                                                                                                ]
+                                                                                              ) ;
+                                                                           rdf:type owl:Class
+                                                                         ] ;
+                                                     rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                     <http://www.w3.org/2004/02/skos/core#definition> "A term in a folksonomy used to categorize things. Tags can be made up on the fly by users." ;
+                                                     <http://www.w3.org/2004/02/skos/core#prefLabel> "Tag" ;
+                                                     <http://www.w3.org/2004/02/skos/core#scopeNote> "Whether to use gist:containedText or gist:uniqueText on tags is an implementation decision." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Task
+<https://w3id.org/semanticarts/ns/ontology/gist/Task> rdf:type owl:Class ;
+                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Event>
+                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGoal> ;
+                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Intention>
+                                                                                                 ]
+                                                                                               ) ;
+                                                                            rdf:type owl:Class
+                                                                          ] ;
+                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "A piece of work that is either proposed, planned, scheduled, underway, or completed." ;
+                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Task" ;
+                                                      <http://www.w3.org/2004/02/skos/core#scopeNote> "Something that could potentially be executed, which is merely described but not proposed in any specific way, such as a business process for onboarding a new employee, or the steps in a recipe for making polyethylene from ethylene, is not a task but rather a task template." ,
+                                                                                                      "Use the property isBasedOn to link a Task back to the TaskTemplate." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/TaskTemplate
+<https://w3id.org/semanticarts/ns/ontology/gist/TaskTemplate> rdf:type owl:Class ;
+                                                              owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Template>
+                                                                                                         [ rdf:type owl:Restriction ;
+                                                                                                           owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasGoal> ;
+                                                                                                           owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Intention>
+                                                                                                         ]
+                                                                                                       ) ;
+                                                                                    rdf:type owl:Class
+                                                                                  ] ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "An outline of a task of a particular type, which is the basis for executing such tasks." ;
+                                                              <http://www.w3.org/2004/02/skos/core#example> "A business process for onboarding new employees." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "Task Template" ;
+                                                              <http://www.w3.org/2004/02/skos/core#scopeNote> "A task template may define a single activity or a series of activities; the level of granularity can be varied according to use case. For example, in a new employee onboarding process, signing up for benefits might be one activity, or it might be broken down into signing up for health insurance, signing up for dental insurance, etc." ,
+                                                                                                              "Use the property isBasedOn to link the Task back to the TaskTemplate." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Taxonomy
+<https://w3id.org/semanticarts/ns/ontology/gist/Taxonomy> rdf:type owl:Class ;
+                                                          owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/ControlledVocabulary>
+                                                                                                     [ rdf:type owl:Restriction ;
+                                                                                                       owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                      ] ;
+                                                                                                       owl:someValuesFrom [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Category>
+                                                                                                                                                 [ rdf:type owl:Class ;
+                                                                                                                                                   owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                                                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasBroader> ;
+                                                                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Category>
+                                                                                                                                                                 ]
+                                                                                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                                                                                   owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/hasBroader>
+                                                                                                                                                                                  ] ;
+                                                                                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Category>
+                                                                                                                                                                 ]
+                                                                                                                                                               )
+                                                                                                                                                 ]
+                                                                                                                                               ) ;
+                                                                                                                            rdf:type owl:Class
+                                                                                                                          ]
+                                                                                                     ]
+                                                                                                   ) ;
+                                                                                rdf:type owl:Class
+                                                                              ] ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "A controlled vocabulary arranged as a hierarchy of concepts." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Taxonomy" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Template
+<https://w3id.org/semanticarts/ns/ontology/gist/Template> rdf:type owl:Class ;
+                                                          owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                          rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "Something used to make objects in its own image." ;
+                                                          <http://www.w3.org/2004/02/skos/core#example> "A die in manufacturing that is used to make stamped parts." ,
+                                                                                                        "A form. A filled-in form has the structure of the form with data entered into some or all of the fields." ,
+                                                                                                        "Cookie cutters are templates for cookies." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "Template" ;
+                                                          <http://www.w3.org/2004/02/skos/core#scopeNote> "Use gist:isBasedOn to link the object made from the template back to the template." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/TemporalRelation
+<https://w3id.org/semanticarts/ns/ontology/gist/TemporalRelation> rdf:type owl:Class ;
+                                                                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasParticipant> ;
+                                                                                    owl:minCardinality "2"^^xsd:nonNegativeInteger
+                                                                                  ] ,
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/startDateTime> ;
+                                                                                    owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                                  ] ;
+                                                                  rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                                  <http://www.w3.org/2004/02/skos/core#definition> "A relationship existing for a period of time." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#example> "employs-Employment, hasAddress-EstablishedLocation. One important context for reifying a property." ;
+                                                                  <http://www.w3.org/2004/02/skos/core#prefLabel> "Temporal Relation" ;
+                                                                  <http://www.w3.org/2004/02/skos/core#scopeNote> "A temporal relation must have a minimum of two participants. For example, both the employer and the employee are participants in a temporal relation representing a period of employment." ,
+                                                                                                                  "Note that 'participant' does not imply agency; a non-sentient being can be participate in a temporal relation. For example, both a person and a house could be participants in a hypothetical relation 'lives at.'" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Text
+<https://w3id.org/semanticarts/ns/ontology/gist/Text> rdf:type owl:Class ;
+                                                      owl:equivalentClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Content>
+                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/isExpressedIn> ;
+                                                                                                   owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/Language>
+                                                                                                 ]
+                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                   owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/containedText> ;
+                                                                                                   owl:someValuesFrom xsd:string
+                                                                                                 ]
+                                                                                               ) ;
+                                                                            rdf:type owl:Class
+                                                                          ] ;
+                                                      rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "Content expressed as words and numbers (not graphics)." ;
+                                                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Text" .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/TimeInterval
+<https://w3id.org/semanticarts/ns/ontology/gist/TimeInterval> rdf:type owl:Class ;
+                                                              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasMagnitude> ;
+                                                                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                                owl:onClass [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Magnitude>
+                                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                                     owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/hasAspect> ;
+                                                                                                                     owl:hasValue <https://w3id.org/semanticarts/ns/data/gist/_Aspect_duration>
+                                                                                                                   ]
+                                                                                                                 ) ;
+                                                                                              rdf:type owl:Class
+                                                                                            ]
+                                                                              ] ,
+                                                                              [ rdf:type owl:Restriction ;
+                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/endDateTime> ;
+                                                                                owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                              ] ,
+                                                                              [ rdf:type owl:Restriction ;
+                                                                                owl:onProperty <https://w3id.org/semanticarts/ns/ontology/gist/startDateTime> ;
+                                                                                owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                              ] ;
+                                                              rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "A span of time with a known start time, end time, and duration. As long as two of the three are known, the third can be inferred." ;
+                                                              <http://www.w3.org/2004/02/skos/core#example> "7pm to 9pm on Jan 1, 2001; fiscal year 2023 (according to some particular definition of fiscal year); the week starting at midnight of January 12, 2023 and lasting exactly 168 hours." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "Time Interval" ;
+                                                              <http://www.w3.org/2004/02/skos/core#scopeNote> "An ongoing state of affairs with an unknown end time in the future cannot be a time interval; e.g. the lifespan of a living person cannot be a time interval, as the end time is unknown." ,
+                                                                                                              "This is distinct from a duration, which describes how long a time interval lasts (e.g., one hour; 3 days; 22 minutes)." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/Transaction
+<https://w3id.org/semanticarts/ns/ontology/gist/Transaction> rdf:type owl:Class ;
+                                                             rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Event> ;
+                                                             rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                             <http://www.w3.org/2004/02/skos/core#definition> "An exchange or transfer of goods, services, or funds." ;
+                                                             <http://www.w3.org/2004/02/skos/core#prefLabel> "Transaction" ;
+                                                             <http://www.w3.org/2004/02/skos/core#scopeNote> "Different sorts of transactions can have different datetime precisions. For example, an electronic transaction would have a gist:actualEndMicrosecond." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup
+<https://w3id.org/semanticarts/ns/ontology/gist/UnitGroup> rdf:type owl:Class ;
+                                                           rdfs:subClassOf [ owl:intersectionOf ( <https://w3id.org/semanticarts/ns/ontology/gist/Collection>
+                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                    owl:onProperty [ owl:inverseOf <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf>
+                                                                                                                   ] ;
+                                                                                                    owl:someValuesFrom <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure>
+                                                                                                  ]
+                                                                                                ) ;
+                                                                             rdf:type owl:Class
+                                                                           ] ;
+                                                           owl:disjointWith <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> ;
+                                                           rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "A collection of units of measure that can all be used to measure the same aspects." ;
+                                                           <http://www.w3.org/2004/02/skos/core#example> "The units of measure bit, byte, kilobit, kilobyte, etc. are all in the same unit group because they can all be used to measure an amount of data." ;
+                                                           <http://www.w3.org/2004/02/skos/core#prefLabel> "Unit Group" ;
+                                                           <http://www.w3.org/2004/02/skos/core#scopeNote> "Typically there is one unit group per aspect. An example of an aspect with two unit groups is vehicle efficiency, which can be measured by miles per gallon (distance per volume) or by liters per 100 kilometers (volume per distance). These two units of measure need to be in different unit groups because they have different values of exponents. When adding a unit of measure to a unit group, make sure it has the same exponents as the other members of the unit group." .
+
+
+###  https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure
+<https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> rdf:type owl:Class ;
+                                                               rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "A standard amount used to measure or specify things." ;
+                                                               <http://www.w3.org/2004/02/skos/core#example> "An acre is a unit for measuring area." ;
+                                                               <http://www.w3.org/2004/02/skos/core#prefLabel> "Unit of Measure" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Advertizing_Agency
+:Advertizing_Agency rdf:type owl:Class ;
+                    rdfs:subClassOf :Business_Organization ;
+                    dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                    dct:created "2025-01-10T23:54:34Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Advocacy_Organization
+:Advocacy_Organization rdf:type owl:Class ;
+                       rdfs:subClassOf :Non-Profit_Organization ;
+                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                       dct:created "2025-01-10T23:55:51Z"^^xsd:dateTime ;
+                       :membership <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+                       :political_mobilization :Public_Agenda ;
+                       :press_events :Media_Agenda .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Agenda
+:Agenda rdf:type owl:Class ;
+        rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Intention> ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-17T21:43:21Z"^^xsd:dateTime ;
+        rdfs:isDefinedBy "https://cssn.org/news-research/europe-volume/ p. 7" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Agent
+:Agent rdf:type owl:Class ;
+       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+       dct:created "2025-01-10T22:48:04Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Alignment
+:Alignment rdf:type owl:Class ;
+           rdfs:subClassOf :Green_Washing ;
+           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+           dct:created "2025-01-14T01:03:46Z"^^xsd:dateTime ;
+           <http://www.w3.org/2004/02/skos/core#definition> """Inconsistent organization in practice
+Claim does not reflect consistent organizational practice""" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Book
+:Book rdf:type owl:Class ;
+      rdfs:subClassOf :Document ;
+      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+      dct:created "2025-01-29T00:44:51Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Book_Chapter
+:Book_Chapter rdf:type owl:Class ;
+              rdfs:subClassOf :Document ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-29T00:45:04Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Business_Organization
+:Business_Organization rdf:type owl:Class ;
+                       rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ;
+                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                       dct:created "2025-01-10T23:53:25Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/CAP_Code
+:CAP_Code rdf:type owl:Class ;
+          rdfs:subClassOf :Industry_Code ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-22T02:24:30Z"^^xsd:dateTime ;
+          <http://www.w3.org/2004/02/skos/core#definition> """**Overview of the CAP Code**
+
+1. **What it is**  
+   - The “CAP Code” refers to the *UK Code of Non-broadcast Advertising and Direct & Promotional Marketing*.  
+   - It is drawn up by the Committee of Advertising Practice (CAP).  
+   - It covers non-broadcast advertising (e.g., print, online, social media, direct marketing, and promotional marketing).  
+   - Although people sometimes assume it is part of UK statutory law, it is in fact a *self-regulatory code*.
+
+2. **Who enforces it**  
+   - The UK’s independent advertising regulator, the Advertising Standards Authority (**ASA**), administers and enforces the CAP Code.  
+   - The ASA is not a government body but is recognized by the government and by the courts as the lead regulator for advertising in the UK. It operates largely as a self-regulatory organization but also works in partnership with bodies that do have statutory powers (e.g., Trading Standards).
+
+---
+
+**How Enforcement Works**
+
+1. **ASA Rulings**  
+   - If the ASA finds an advertisement in breach of the CAP Code (for instance, for being misleading, harmful, or offensive), it will issue a formal ruling.  
+   - The advertiser must then *amend or withdraw* the offending ad.  
+   - The ASA publishes its rulings on its website, which can lead to reputational damage—“naming and shaming” advertisers who break the rules.
+
+2. **Sanctions**  
+   - If an advertiser refuses to comply with an ASA ruling, a series of escalating sanctions can follow:  
+     - **Ad Alerts**: The ASA can send bulletins to media owners urging them not to run the advertiser’s ads until they comply.  
+     - **Pre-vetting/Pre-clearance**: The advertiser may be required to have all future ads checked and approved by the ASA or CAP before publication.  
+     - **Referral to Trading Standards**: In serious or persistent cases, the ASA can refer the advertiser to Trading Standards, which *does* have statutory powers (including the ability to levy fines or prosecute if the ad breaks consumer protection laws).
+
+3. **Fines and legal penalties**  
+   - The ASA itself *does not usually fine* advertisers (as it is not a statutory body). Its main powers are rulings, instructions not to run certain ads, and reputational/regulatory pressure.  
+   - However, if the advertiser persists in breaking the rules or is found to be misleading consumers in a way that violates consumer protection legislation, the matter can be escalated to Trading Standards or other statutory bodies.  
+   - In those cases, the advertiser could face formal legal action, including *fines, penalties, or prosecutions*.
+
+---
+
+**Key Takeaways**
+
+- The CAP Code is a *self-regulatory* set of guidelines for non-broadcast advertising in the UK—*not* a piece of primary legislation.  
+- The ASA enforces the CAP Code by issuing rulings and imposing various sanctions designed to ensure compliance (such as withdrawing ads, naming and shaming, or pre-clearing future ads).  
+- While the ASA does *not* typically issue fines in its own right, it can refer persistent or serious offenders to bodies with *statutory powers* (e.g., Trading Standards), which *can* impose fines or other legal actions.  
+- Therefore, although the CAP Code itself is not “the law,” it is underpinned by strong industry commitment and the possibility of legal enforcement if a business repeatedly flouts the Code or breaches consumer protection laws.
+
+Source: ChatGPT""" ,
+                                                           """UK Code of Non-broadcast Advertising and Direct & Promotional Marketing, issued by the Committee of Advertising Practice (CAP). It sets out the rules that govern advertising in the UK (excluding TV and radio, which are covered by the BCAP Code). The Advertising Standards Authority (ASA) enforces these rules.
+
+Key points about the CAP Code:
+
+Scope: It applies to most forms of non-broadcast marketing communications, including print ads, online ads, social media posts (including influencer marketing), email marketing, and promotional materials.
+
+Aim: The CAP Code is designed to ensure that ads are legal, decent, honest, and truthful. It also sets standards for areas like misleading advertising, harm and offence, children’s advertising, and more.
+
+Enforcement: The ASA investigates complaints from the public and can request that advertisers amend or withdraw advertisements that breach the Code.
+Source: ChatGPT""" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Campaign_Funding_PAC
+:Campaign_Funding_PAC rdf:type owl:Class ;
+                      rdfs:subClassOf :Non-Profit_Organization ;
+                      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                      dct:created "2025-01-10T23:59:16Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/City
+:City rdf:type owl:Class ;
+      rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+      dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Communication
+:Communication rdf:type owl:Class ;
+               rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Event> ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-14T00:55:26Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Conservative_Media_Corporation
+:Conservative_Media_Corporation rdf:type owl:Class ;
+                                rdfs:subClassOf :Media_Corporation ;
+                                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                dct:created "2025-01-11T00:00:33Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Continent
+:Continent rdf:type owl:Class ;
+           rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/GeoRegion> ;
+           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+           dct:created "2025-01-31T02:39:46Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Corporation
+:Corporation rdf:type owl:Class ;
+             rdfs:subClassOf :Business_Organization ;
+             dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+             dct:created "2025-01-10T23:57:09Z"^^xsd:dateTime ;
+             rdfs:comment "tem" ;
+             :funding_and_political_service :Trade_Association ;
+             :funding_and_research_agendas :University ;
+             :money :Advertizing_Agency ,
+                    :Advocacy_Organization ,
+                    :Campaign_Funding_PAC ,
+                    :Lobbying_Firm ,
+                    :Think_Tank ;
+             :testimony_at_hearings :Political_Agenda .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/County
+:County rdf:type owl:Class ;
+        rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Court
+:Court rdf:type owl:Class ;
+       rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ;
+       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+       dct:created "2025-01-30T02:58:05Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/District
+:District rdf:type owl:Class ;
+          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Document
+:Document rdf:type owl:Class ;
+          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Content> ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-31T02:48:36Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Empty_Claims
+:Empty_Claims rdf:type owl:Class ;
+              rdfs:subClassOf :Impact ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-14T04:21:26Z"^^xsd:dateTime ;
+              <http://www.w3.org/2004/02/skos/core#definition> "Making claims/policies that either exaggerate achievements, or fail to live up to them" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/False_Communication
+:False_Communication rdf:type owl:Class ;
+                     rdfs:subClassOf :Green_Washing ;
+                     dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                     dct:created "2025-01-14T01:03:46Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Falsehoods
+:Falsehoods rdf:type owl:Class ;
+            rdfs:subClassOf :Impact ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-14T04:21:26Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Foundation
+:Foundation rdf:type owl:Class ;
+            rdfs:subClassOf :Non-Profit_Organization ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-10T23:52:35Z"^^xsd:dateTime ;
+            :money :Think_Tank .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Green_Washing
+:Green_Washing rdf:type owl:Class ;
+               rdfs:subClassOf :Communication ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-14T00:55:49Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Impact
+:Impact rdf:type owl:Class ;
+        rdfs:subClassOf :Green_Washing ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-14T01:03:46Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Industry_Code
+:Industry_Code rdf:type owl:Class ;
+               rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Commitment> ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-22T02:19:41Z"^^xsd:dateTime ;
+               <http://www.w3.org/2004/02/skos/core#definition> "Guidelines and standards defined by an Industry group rather than a Government or an NGO such as the UN. The Cap Code that sets enforceable guidelines by Cap in the UK is an example." .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Industry_Regulatory_Body
+:Industry_Regulatory_Body rdf:type owl:Class ;
+                          rdfs:subClassOf :Business_Organization ;
+                          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                          dct:created "2025-01-23T03:28:07Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Irrelevant
+:Irrelevant rdf:type owl:Class ;
+            rdfs:subClassOf :Impact ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-14T04:21:26Z"^^xsd:dateTime ;
+            <http://www.w3.org/2004/02/skos/core#definition> "Proclaiming accomplishments that are irrelevant or already required by law/competitors" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Journal_Article
+:Journal_Article rdf:type owl:Class ;
+                 rdfs:subClassOf :Document ;
+                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                 dct:created "2025-01-30T18:43:31Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Litigation
+:Litigation rdf:type owl:Class ;
+            rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Commitment> ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-29T23:54:00Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Lobbying_Firm
+:Lobbying_Firm rdf:type owl:Class ;
+               rdfs:subClassOf :Business_Organization ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-10T23:58:46Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Media_Agenda
+:Media_Agenda rdf:type owl:Class ;
+              rdfs:subClassOf :Agenda ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-17T21:44:35Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Media_Corporation
+:Media_Corporation rdf:type owl:Class ;
+                   rdfs:subClassOf :Corporation ;
+                   dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                   dct:created "2025-01-10T23:59:46Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Nation
+:Nation rdf:type owl:Class ;
+        rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Non-Profit_Organization
+:Non-Profit_Organization rdf:type owl:Class ;
+                         rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Organization> ;
+                         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                         dct:created "2025-01-10T23:55:06Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Not_Credible
+:Not_Credible rdf:type owl:Class ;
+              rdfs:subClassOf :Impact ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-14T04:21:26Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Political_Agenda
+:Political_Agenda rdf:type owl:Class ;
+                  rdfs:subClassOf :Agenda ;
+                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                  dct:created "2025-01-17T21:44:35Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Proposition
+:Proposition rdf:type owl:Class ;
+             dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+             dct:created "2025-01-24T00:17:47Z"^^xsd:dateTime ;
+             <http://www.w3.org/2004/02/skos/core#definition> """A proposition is a central concept in the philosophy of language, semantics, logic, and related fields, often characterized as the primary bearer of truth or falsity. Propositions are also often characterized as the type of object that declarative sentences denote. For instance, the sentence \"The sky is blue\" denotes the proposition that the sky is blue. However, crucially, propositions are not themselves linguistic expressions. For instance, the English sentence \"Snow is white\" denotes the same proposition as the German sentence \"Schnee ist weiß\" even though the two sentences are not the same. Similarly, propositions can also be characterized as the objects of belief and other propositional attitudes. For instance if someone believes that the sky is blue, the object of their belief is the proposition that the sky is blue.
+
+Source: https://en.wikipedia.org/wiki/Proposition""" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Province
+:Province rdf:type owl:Class ;
+          rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Public_Agenda
+:Public_Agenda rdf:type owl:Class ;
+               rdfs:subClassOf :Agenda ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-17T21:44:35Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Selective_Disclosure
+:Selective_Disclosure rdf:type owl:Class ;
+                      rdfs:subClassOf :Impact ;
+                      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                      dct:created "2025-01-14T04:19:51Z"^^xsd:dateTime ;
+                      rdfs:isDefinedBy <https://cssn.org/special-projects/greenwashing-tool/impact/> ;
+                      <http://www.w3.org/2004/02/skos/core#definition> """1.1 Does the organization fail to disclose relevant information regarding the environmental claim being made, such as lifecycle or cumulative impacts?
+
+If yes...−
+IT'S GREENWASHING
+For assessing this indicator, it is important to understand whether a) the exact scope of action and b) the limitations or system boundaries are transparently communicated. Even if not all stages of life cycle or not all scopes/cumulative impacts can be assessed for the claim, if boundaries are clearly communicated (what is and what is not assessed) and there is a clear pathway of improving the coverage of scope, that is not a greenwash. Likewise, the claimed product/service should not contribute to any significant negative impacts on the environment nor should result in an undue transfer of such impacts (unless the total net environmental benefit has been significantly improved). Life Cycle Analysis (LCA) is the most often used tool to assess different environmental aspects, although this approach comes with limitations. When assessing a claim related to environmental impacts, the product/service’s impact over its whole life cycle (on and off-site) is relevant. For the organization's impacts, the GRI Standards could provide an extensive list of specific measures. For products, all production steps including (where applicable) extraction through production, use, and postuse need to be included. An LCA should follow internationally accepted standards (e.g. ISO14000 series (ISO 2006)). Claims lead to greenwashing where they reflect only part of the life cycle/impacts and do not make clear which part they refer to thereby creating a misleading impression about the overall impact on the environment.""" ,
+                                                                       """1.2 When making a comparison, does the claim provide insufficient information to assess the difference between the claim and alternatives?
+
+If yes...−
+IT'S GREENWASHING
+Absolute claims need to be supported by a high level of substantiation. Comparative claims such as “greener” “friendlier” \"more sustainable\" can be justified if the advertised product/organization/service provides environmental benefit over that of the organizations’ previous products/services or competitors’ products/services, and the basis of the comparison is clear. Similarly, if the advertised \"better/greener\" products/services only constitute a minority of the same product/service range within the organization creating the impression that it is the dominant type of product/service, this has to be transparently communicated, otherwise it falls under this category of greenwashing.""" ,
+                                                                       """1.3 Is a claim of environmental neutrality based on offsetting rather than reduction of direct environmental harm?
+
+If yes...−
+IT'S GREENWASHING
+Claiming biodiversity or carbon neutrality or a reduction of environmental harm based predominantly on offsetting can mislead people to believe that the claimant is doing more to mitigate environmental harm than they are. For many, overuse of offsetting risks justifying the continuation of business-as-usual practices that damage the environment. Decades of experience with offsets have proven that they are unlikely to provide real long-term gains to balance the certain, often irreversible, destruction resulting from certain business activities. Terms such as “climate neutral” or “climate positive” that rely on offsetting will be banned from the EU by 2026 as part of a new regulations on misleading environmental claims. IUCN, a respected global authority on the state of nature and what is needed to safeguard it, concluded that “…evidence is lacking as to the extent to which no net loss (NNL) / net gains (NG) and offset policies are achieving their goals or contributing to better biodiversity outcomes in the jurisdictions where they exist.” (IUCN, 2014) (NewClimate Institute, 2020). At the same time, well-meaning investments by organizations in environmental protection projects are very much needed and they can be communicated. To this end, NewClimate’s Climate Responsibility approach (NewClimate Institute, 2020) calls for financially supporting others’ climate action, and disclosing that support within company reports, while not using them to “net-out’’ own impacts.""" ,
+                                                                       "Claim is based on a narrow set of attributes and distracts consumers from the organization's greater environmental impact" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/State
+:State rdf:type owl:Class ;
+       rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+       dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Status
+:Status rdf:type owl:Class ;
+        owl:equivalentClass [ rdf:type owl:Class ;
+                              owl:oneOf ( :Decided
+                                          :Pending
+                                        )
+                            ] ;
+        rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/Category> ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-29T22:17:06Z"^^xsd:dateTime ;
+        rdfs:comment "Will add more status values based on data" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Think_Tank
+:Think_Tank rdf:type owl:Class ;
+            rdfs:subClassOf :Non-Profit_Organization ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-24T22:27:28Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Town
+:Town rdf:type owl:Class ;
+      rdfs:subClassOf <https://w3id.org/semanticarts/ns/ontology/gist/CountryGeoRegion> ;
+      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+      dct:created "2025-01-30T02:53:11Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Trade_Association
+:Trade_Association rdf:type owl:Class ;
+                   rdfs:subClassOf :Non-Profit_Organization ;
+                   dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                   dct:created "2025-01-10T23:57:36Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/University
+:University rdf:type owl:Class ;
+            rdfs:subClassOf :Non-Profit_Organization ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-10T23:58:21Z"^^xsd:dateTime ;
+            :expert_sources :Media_Agenda ;
+            :testimony_at_hearings :Political_Agenda .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Web_Page
+:Web_Page rdf:type owl:Class ;
+          rdfs:subClassOf :Document ;
+          dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+          dct:created "2025-01-29T22:05:30Z"^^xsd:dateTime .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_altitude
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_altitude> rdf:type owl:NamedIndividual ,
+                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "The aspect altitude." ;
+                                                              <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "area" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_area
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_area> rdf:type owl:NamedIndividual ,
+                                                                   <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The aspect area." ;
+                                                          <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "area" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_duration
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_duration> rdf:type owl:NamedIndividual ,
+                                                                       <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                              <http://www.w3.org/2004/02/skos/core#definition> "The aspect duration." ;
+                                                              <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                              <http://www.w3.org/2004/02/skos/core#prefLabel> "duration" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_financial_balance
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_financial_balance> rdf:type owl:NamedIndividual ,
+                                                                                <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                                       <http://www.w3.org/2004/02/skos/core#definition> "The aspect financial balance." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                                       <http://www.w3.org/2004/02/skos/core#prefLabel> "balance" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_mass
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_mass> rdf:type owl:NamedIndividual ,
+                                                                   <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "The aspect mass." ;
+                                                          <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                          <http://www.w3.org/2004/02/skos/core#prefLabel> "mass" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_monetary_value
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_monetary_value> rdf:type owl:NamedIndividual ,
+                                                                             <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                                    <http://www.w3.org/2004/02/skos/core#definition> "The aspect monetary value." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                                    <http://www.w3.org/2004/02/skos/core#prefLabel> "monetary value" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_probability
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_probability> rdf:type owl:NamedIndividual ,
+                                                                          <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "The aspect probability." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                                 <http://www.w3.org/2004/02/skos/core#prefLabel> "probability" .
+
+
+###  https://w3id.org/semanticarts/ns/data/gist/_Aspect_volume
+<https://w3id.org/semanticarts/ns/data/gist/_Aspect_volume> rdf:type owl:NamedIndividual ,
+                                                                     <https://w3id.org/semanticarts/ns/ontology/gist/Aspect> ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "The aspect volume." ;
+                                                            <http://www.w3.org/2004/02/skos/core#editorialNote> "This instance has been duplicated from reference data so it can be used in property restrictions." ;
+                                                            <http://www.w3.org/2004/02/skos/core#prefLabel> "volume" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/ASA_Ruling_on_Repsol_SA
+:ASA_Ruling_on_Repsol_SA rdf:type owl:NamedIndividual ,
+                                  :Selective_Disclosure ;
+                         <https://w3id.org/semanticarts/ns/ontology/gist/containedText> """2. Upheld
+
+The CAP Code required that the basis of environmental claims must be clear.
+
+We acknowledged Repsol’s target to reach net zero emissions by 2050 and their objectives regarding emissions from operating assets, net emissions and methane emissions. We also acknowledged their aims and investments regarding biofuels and synthetic fuels. Further we noted the changes made to their investment process. We understood, however, that Repsol did not only accept investment opportunities based on carbon reducing activity.
+
+We acknowledged Repsol’s comment that there is no single solution for sustainability, and that renewable fuels are one element in the company’s strategy to reach net zero by 2050. However, while we agreed that synthetic fuels and biofuels could contribute towards Repsol’s goal of achieving net zero emissions, they would not as a single measure ‘achieve’ net zero emissions. We also considered that in the context of an ad making a claim based on initiatives to achieve net zero, the timeframe of 2050 to achieve that goal was material information that needed to be made clear to consumers.
+
+In the absence of any contextual information explaining that the initiative was part of a wider plan to achieve net zero by 2050, we concluded that the basis of the claim “At Repsol, we are developing biofuels and synthetic fuels to achieve net zero emissions” was not clear and it was likely to mislead as a result.
+
+On this point, the ad breached CAP Code (Edition 12) rule 3.1, 3.11 (Misleading Advertising), and 11.1 (Environmental Claims).
+
+Action
+The ad must not appear again in the form complained of. We told Repsol that the basis of environmental claims in future marketing communications must be clear, and to ensure that their marketing communications did not misleadingly omit material information, such as how and when Repsol would achieve net zero emissions, and the role that the development of biofuels would play in that plan.""" ,
+                                                                                        """Ad description
+A paid-for online display ad for Repsol, a global energy company, seen on a newspaper website on 2 February 2023, featured several images of leaves with text that stated, “At Repsol, we are developing biofuels and synthetic fuels to achieve net zero emissions”. After which a car was shown parked in a wooded area, surrounded by leaves, with text that stated, “Renewable fuels for more sustainable mobility”. In the top left-hand corner of the ad was a stylised outline of a petrol pump within which was a leaf.""" ,
+                                                                                        """Assessment
+1. Upheld
+
+The ASA welcomed Repsol’s assurance that the ad would be removed. The CAP Code stated that unqualified claims could mislead if material information was omitted.
+
+The ad appeared within the FT’s digital energy newsletter and elsewhere on the FT website. It would therefore have been seen by both consumers, who may be interested in Repsol as a brand for the products and services they provide, and business readers, such as potential investors, partners and clients. We considered that both audiences would have an awareness that many companies in carbon-intensive industries, including the oil and gas sector, aimed to dramatically reduce their emissions in response to the climate crisis. In addition, both were increasingly concerned about the environmental impact of activities related to higher-carbon products and services, and would be interested in seeking out businesses, including oil and gas companies, who were making meaningful progress towards transitioning away from higher-carbon products and services, including towards achieving net zero emissions. However, we considered that consumers and many business readers were unlikely to be aware of the specific details of how companies planned to achieve this.
+
+We considered that both consumers and business readers were likely to interpret the claim, “At Repsol, we are developing biofuels and synthetic fuels to achieve net zero emissions”, in addition to the imagery of nature and the natural environment, as meaning that Repsol’s development of biofuels and synthetic fuels formed a significant element of their current activities that were making meaningful progress towards achieving net zero emissions.
+
+We acknowledged Repsol’s comments regarding their contribution to electrical charging, renewable generation capacity, and reductions in energy consumption and emissions in industrial centres in other facilities. However, notwithstanding current actions towards improving their environmental impact, we understood that a number of Repsol’s new biofuel and synthetic fuel initiatives were not yet in operation. Furthermore, Repsol’s carbon emissions stood at 171 million tonnes of CO2e in 2021 (50% of the emissions of the United Kingdom in 2021, 346.7 Mt CO2e). They produced approximately 600,000 barrels of oil per day. We also understood that Repsol had a substantial oil and gas exploration strategy, owning an interest in 40,660 acres (gross) of oil and gas development and exploration across Europe, Latin America, North America, Africa, and Asia and Oceania.
+
+We acknowledged that Repsol’s hydrocarbons production focused on gas and understood the reasons for that. We also acknowledged that oil would continue to play a legitimate role in the context of energy transition in the future. However, we understood that their focus on the production of biofuels and synthetic fuels to achieve net zero emissions was a fraction of their business activities when compared to their substantial, ongoing, and expanding fossil fuel production. Furthermore, notwithstanding the reasons given for the continued production of oil and gas, we noted that the ad focused solely on an initiative the company suggested would deliver their net zero goal (with no timeframe given) when at the same time, Repsol was continuing to emit notable levels of carbon dioxide and other greenhouse gasses and would do so for many years into the future.
+
+We understood that consumers could access information about Repsol’s general business activities and plans on their website. However, further information to contextualise how and when Repsol would achieve net zero emissions, and the role that the development of biofuels would play in that plan, was material to consumers’ understanding of the ad’s overall message, and should have appeared in the ad itself.
+
+We therefore concluded that the ad omitted material information and was misleading.
+
+On this point, the ad breached CAP Code (Edition 12) rules 3.1, 3.3 (Misleading Advertising), and 11.1 (Environmental Claims).""" ,
+                                                                                        """Background
+Summary of Council decision:
+
+Two issues were investigated, both of which were Upheld.""" ,
+                                                                                        """Issue
+1. Adfree Cities, who understood that Repsol’s business activities included substantial, ongoing and expanding fossil fuel production, challenged whether the ad was misleading because it omitted significant information about the overall impact of Repsol’s business activities.
+
+2. The ASA challenged whether the basis of the claim “At Repsol, we are developing biofuels and synthetic fuels to achieve net zero emissions” was clear.""" ,
+                                                                                        """Response
+1. Repsol said that by adding the message “Find out more about this and other projects”, accompanied by a button with the message “More information” at the end of the ad, the reader was invited to click and access Repsol’s website. Once accessed, the website provided further information and news related to the company’s global activity. They believed that it was impossible to maintain the attractiveness of the ad and place more information within it.
+
+Repsol explained that the ad was mainly designed for inclusion in the Financial Times (FT) digital energy newsletter sponsored by Repsol, aimed at an informed audience of users who subscribe to it and are interested in issues and news related to the energy sector. They acknowledged that the ad was also published elsewhere on the FT’s website.
+
+Repsol said that they opened Spain’s first electric charging point, and operated Spain’s largest public electric vehicle charging network. In addition, they are a significant operator in the electricity and gas market in Spain, with 1.5 million customers. They currently have an installed renewable generation capacity of more than 1,800 MW worldwide and plan to reach 6,000 MW by 2025 and 20,000 MW by 2030. They produce an average of approximately 600,000 barrels of oil equivalent per day, of which nearly 70% is gas. Their hydrocarbons production is focused on gas since the fuel helps transition from higher-emissions coal to electricity production, thus speeding up the energy transition. They further stated that oil will still be needed in a more decarbonized world, even according to the International Energy Agency’s most aggressive scenarios.
+
+Repsol summarised that they have reduced energy consumption in their industrial centres by 20% in the period 2011-2022 and reduced emissions by more than 20% in all their facilities.
+
+2. Repsol said they were aware that there is no single solution for sustainability. They explained that renewable fuels are one of the main elements in the company’s strategy to reach net zero by 2050. They aimed to reduce 55% of emissions from operated assets and 30% of net emissions by 2030. They also stated that they set a target for reducing their methane emissions intensity to 0.20% in 2025, which would be a reduction of 85%.
+
+Repsol said that they will allocate more than €5 billion in organic investment and that 35% of these investments will be allocated to low-carbon technologies and projects. The company has implemented a methodology to determine whether a new investment is in line with its decarbonisation targets, and any investment proposed to the Executive Committee and the Board of Directors must include a report prepared by their Sustainability Department. In the second half of 2023 they are introducing a new biofuels facility that will supply 250,000 tons per year of advanced biofuels. The use of these fuels will make it possible to avoid emissions of 900,000 tons of carbon dioxide per year. They also are preparing to build synthetic fuels and urban waste recovery plants and have partnered with Enerkem to develop a plant which will process around 400,000 tons of non-recyclable municipal solid waste to produce around 240,000 tons of renewable methanol (biomethanol).
+
+Repsol explained that renewable fuels make up 10% of their fuel sales in Spain and they expect to grow this aggressively. They have existing pilot projects in three cities which involve 100% biofuel pumps for fleet vehicles and have also launched a recent initiative to pay customers for their used cooking oil for incorporation into the processing of fatty residues. Repsol said they are committed to acting ethically and would remove the ad immediately.""" ;
+                         <https://w3id.org/semanticarts/ns/ontology/gist/isRecordedAt> "2023-06-07T00:00:00"^^xsd:dateTime ;
+                         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                         dct:created "2025-01-21T22:56:25Z"^^xsd:dateTime ;
+                         rdfs:isDefinedBy <https://www.asa.org.uk/rulings/repsol-sa-a23-1185942-repsol-sa.html> ;
+                         rdfs:label "ASA Ruling on Repsol SA" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/A_Sociological_View_of_Efforts_to_Obstruct_Climate_Action
+:A_Sociological_View_of_Efforts_to_Obstruct_Climate_Action rdf:type owl:NamedIndividual ,
+                                                                    :Journal_Article ;
+                                                           dct:publisher "Footnotes: A magazine of the American Socilogical Institute" ;
+                                                           <http://purl.org/ontology/bibo/issue> "3" ;
+                                                           <http://purl.org/ontology/bibo/volume> "40" ;
+                                                           :author_string "Robert J. Brulle; Riley E. Dunlap" ;
+                                                           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                           dct:created "2025-01-30T18:43:46Z"^^xsd:dateTime ;
+                                                           rdfs:label "A Sociological View of Efforts to Obstruct Climate Action" ;
+                                                           :url <https://www.asanet.org/footnotes-article/sociological-view-effort-obstruct-action-climate-change/> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Africa
+:Africa rdf:type owl:NamedIndividual ,
+                 :Continent ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-31T02:40:36Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Antarctica
+:Antarctica rdf:type owl:NamedIndividual ,
+                     :Continent ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-31T02:41:21Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Asia
+:Asia rdf:type owl:NamedIndividual ,
+               :Continent ;
+      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+      dct:created "2025-01-31T02:40:42Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Australia
+:Australia rdf:type owl:NamedIndividual ,
+                    :Continent ,
+                    :Nation ;
+           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+           dct:created "2025-01-31T02:42:26Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Avoiding_cultural_trauma_climate_change_and_social_inertia
+:Avoiding_cultural_trauma_climate_change_and_social_inertia rdf:type owl:NamedIndividual ,
+                                                                     :Journal_Article ;
+                                                            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                            dct:created "2025-01-31T02:50:23Z"^^xsd:dateTime ;
+                                                            rdfs:label "Avoiding cultural trauma: climate change and social inertia" ;
+                                                            :url <https://www.tandfonline.com/doi/full/10.1080/09644016.2018.1562138> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Big_Oil_Goes_to_College
+:Big_Oil_Goes_to_College rdf:type owl:NamedIndividual ,
+                                  :Web_Page ;
+                         dct:abstract "Report from Jennifer Washburn analyzes 10 research collaboration contracts between leading energy companies and major U.S. universities." ;
+                         dct:title "Big Oil Goes to College An Analysis of 10 Research Collaboration Contracts Between Leading Energy Companies and Major U.S. Universities" ;
+                         :author_string "Jennifer Washburn" ;
+                         :publication_date "Oct 14, 2010" ;
+                         :text """BP’s total 10-year, $500 million investment in the Energy Biosciences Institute will amount to a mere 0.021 percent of BP’s total projected revenues, and just 0.26 percent of its total profits, during the period 2006-2015.
+This level of R&D spending is not inconsistent with energy industry totals, but it remains well below the average for U.S. industry as a whole. According to energy experts Gregory Nemet and Daniel Kammen, during the years 1988 to 2003, the U.S. energy industry (in its entirety) invested just 0.23 percent of its revenues in R&D, far below the average of 2.6 percent for U.S. industry as a whole.""" ,
+                               """Going green on campus: Big Oil’s media blitz
+Big Oil hasn’t been shy about exploiting its university-research connections to “green” its public image. In an eight-page magazine spread, Chevron proudly proclaims: “We’re partnering with major universities to develop the next generation of biofuels.” In another ad, BP declared: “It’s time to invest in our own backyard… we’re investing $500 million over the next 10 years to establish the Energy Biosciences Institute”—a reference to the alliance, headquartered at U.C. Berkeley, that DOE secretaries Chu and Koonin helped to negotiate.
+
+The boldest of these ads appeared on the influential opinion pages of the New York Times. The ad touted Stanford University’s research partnership with Exxon Mobil, among other companies, through the Global Climate and Energy Project—a deal signed in 2002 that is still ongoing today (and is reviewed in this report). The ad—bearing the official Stanford University seal side by side with the GCEP logo—deeply angered many faculty and students on campus because their perception of that ad strongly suggested that the scientific evidence regarding global climate change was still not conclusive. In addition to bearing the university’s official seal, the ad was signed by Stanford Professor Lynn Orr, then-director of the Exxon-funded GCEP alliance""" ,
+                               """Implications
+The 10 university-industry agreements reviewed for this report reveal a considerable amount about the goals and expectations of the big energy companies as well as the research conditions and constraints that academic researchers at U.S. universities are now operating under as a condition of their acceptance of this private industry financing.
+
+Our review found that the terms and conditions outlined in these 10 agreements do not always show parity between the two sets of research partners. Indeed, the report’s analysis supports the author’s view that, in fundamental respects, the vast majority of these contracts seriously challenge the historic research integrity and the independence of the universities involved.
+
+In the recent past, private industry (through Bell Labs and numerous other corporate research hubs) conducted a substantial amount of scientific research and technological development. Over the past 30 years, however, many private companies have vastly reduced their R&D investments, and downsized or outright eliminated their own inhouse scientific and technological expertise. What research these companies do continue to fund is increasingly contracted out to third parties, including private contract research labs and U.S. universities. This is not true of all firms, of course, but it is certainly true of most of the large, established energy companies, as this report demonstrates.
+
+On campus, meanwhile, the research climate is also rapidly changing. Thirty years ago, large-scale, multi-year strategic corporate research alliances on campus were far less common, and overt academic commercialism was largely taboo. Today the boundary between academic research and commercial research is far more blurry. So far, the long-term consequences of this subtle but important shift in the nation’s science-and-technology infrastructure have not been well explored. This shift is especially important to consider in the energy sector, where independent university scientists and experts are urgently needed to measure and interpret today’s complex global-warming problems, uncover path-breaking new technologies, and provide impartial advice and expertise to the public and government agencies regarding effective public policy.
+
+Because this independent university sector remains so vitally important, the Obama administration, Congress, federal agencies, and university leaders across the country would do well to carefully consider the findings of this report, which point to several intriguing new conclusions regarding the efficacy of developing new sources of alternative energy through joint university-industry research partnerships.
+
+First of all, the manner in which these industry contracts were negotiated and concluded points to numerous potential challenges for future U.S. university negotiators. Many of these agreements fail to make any clear distinctions between independent, academic research and commercial research for hire. If more U.S. universities begin to work with the energy industry through these types of contract-research arrangements then it will be far more difficult for them to continue producing credible, independent energy research in these critical academic fields. One has only to review the extensive science literature on pharmaceutical industry influence and conflicts of interest in academic medicine to see the potential hazards that can arise from tearing down the boundary walls that separate academic and commercial research.
+
+Second, preserving an independent research sector inside top-ranked U.S. universities remains vitally important for the advancement of clean energy research and the health of the U.S. science and innovation system more broadly. U.S. universities have traditionally performed many types of research (curiosity-driven science, fundamental inquiry, disinterested research) that private firms were unable, or unwilling, to finance adequately on their own, because of shorter-term commercial, strategic, and profit considerations. Many of this nation’s most path-breaking scientific discoveries—including those that launched the biotechnology, computing, and information-technology revolutions—were born out of publicly financed research, performed in academic labs.
+
+Of course, private industry has also made enormous contributions to U.S. science and innovation. But until recently, most major firms operated their own independent, commercial R&D labs. It remains highly uncertain what will happen to our nation’s unique academic sector if private industry continues to move its R&D operations onto U.S. campuses without showing adequate respect for the university’s highly distinctive academic research culture.
+
+Third, we need to preserve a research sphere that is committed to public-good research— research that has enormous social value, but which rarely generates commercial profits. In the area of energy research alone, this might include studies comparing the relative social, economic, energy, and environmental consequences of various competing alternativeenergy technologies, or advanced research to measure carbon and other greenhouse gases emitted from various sources, or the development of effective carbon caps, taxes, trading, and measuring systems. Without this type of public-good research—carried out independently of specific commercial- or special-interest groups—it is far more difficult for political leaders and the public to develop effective, enlightened public policies.
+
+Finally, public-private partnerships will certainly be necessary for bringing new cleanenergy research and technologies into the commercial marketplace, whether they originate in academic labs, government labs, or commercial labs. But these partnerships should not be pursued in a manner that compromises the long-term health of this nation’s public research sphere. When U.S. government agencies, including the Department of Energy, issue public-private R&D grants, they should clearly differentiate between the research objectives of American universities and the objectives of the individual private-sector partners. This can be done by crafting standard legal agreements between the federal funding agencies, U.S. universities, and private firms that vigorously protect the universities’ core academic- and public-knowledge missions, including their commitment to self-governance, free inquiry, and research independence. Commercial firms should be required to accept these terms in exchange for government research support.
+
+In the final section of the main report, we offer recommendations for avoiding what we see as the problems with the contracts at these 10 universities, through our “detailed contract reviews” featured in this report’s appendices. The purpose: so the problems will not be repeated at other universities. The goal of these recommendations is to ensure that corporations seeking to partner with U.S. universities to capitalize on academic expertise and resources are not granted excessive commercial influence over the academic research process and, in some instances, overly broad commercial advantages as well. We briefly detail these recommendations here.""" ,
+                               """In nine of the 10 energy-research agreements we analyzed, the university partners failed to retain majority academic control over the central governing body charged with directing the university-industry alliance. Four of the 10 alliances actually give the industry sponsors full governance control.
+Eight of the 10 agreements permit the corporate sponsor or sponsors to fully control both the evaluation and selection of faculty research proposals in each new grant cycle.
+None of the 10 agreements requires faculty research proposals to be evaluated and awarded funding based on independent expert peer review, the traditional method for awarding academic and scientific research grants fairly and impartially based on scientific merit.
+Eight of the 10 alliance agreements fail to specify transparently, in advance, how faculty may apply for alliance funding, and what the specific evaluation and selection criteria will be.
+Nine of the 10 agreements call for no specific management of financial conflicts of interest related to the alliance and its research functions. None of these agreements, for example, specifies that committee members charged with evaluating and selecting faculty research proposals must be impartial, and may not award corporate funding to themselves. (See summary of main findings for details, pages 52-59, and the Appendices beginning on page 75.)""" ,
+                               """It is clear, then, that industry spending on all forms of energy R&D (especially low-carbon energy R&D) remains chronically low. Nevertheless, the industry’s decision to shift more of its already limited R&D spending to U.S. universities is highly significant, and could have far-reaching consequences for the future direction of energy R&D efforts nationally. In large part, this is because the U.S. government commitment to energy R&D has remained persistently low for decades, so every dollar of private industry funding that comes into university labs is urgently needed. Consider that:
+
+From 1993 to 2006, U.S. government spending on all energy-related R&D (in real dollars) remained stuck at roughly $3 billion to $4 billion per year, averaging $3.6 billion per year over this period. This is 60 percent less than the $9 billion the U.S. government spent on energy R&D in 1979. (see graph)
+
+Over the same years, by contrast, real federal spending on defense R&D and health R&D averaged $58 billion and $22 billion per year, respectively. (see graph)
+
+Industry financing of university research is certainly legitimate. Academic-industry research collaborations have led to critical advancements in science and engineering and should be nurtured. Yet industry funding can also have a powerful distorting influence on the quality, topics, and credibility of academic research when it is not properly managed.
+
+Indeed, in recent years a large body of analytic and empirical research has shown that industry-funded studies in sectors ranging from pharmaceuticals to tobacco to food are associated with reported outcomes that strongly favor the corporate sponsor’s products and/or interests compared to studies funded by government and non-profit sources.""" ,
+                               """It’s clear that Big Oil and other large energy companies have ramped up their advertising budgets to project a pro-environmental business orientation. But if we crack open the industry’s annual reports, it is also clear that today’s climate and energy crises (and persistently high oil prices) haven’t had anywhere near the impact on energy industry R&D spending that the earlier oil price shocks of the 1970s once had. After rising sharply in the 1970s, energy industry spending (adjusted for inflation) on all types of R&D has plummeted, from an annual average of nearly $6.4 billion in the early 1980s to an annual average of roughly $1.7 billion at the start of the last decade (see graph).
+
+The annual reports of four of the largest oil companies— ExxonMobil, BP, Shell, and Chevron— between 2000 and 2007 (before the Great Recession began) do show some overall gains in R&D spending. But these R&D gains, which are overwhelmingly directed toward enhanced oil and gas recovery, not clean energy, remain truly marginal, particularly in light of the oil industry’s vast profit margins in recent years. In constant 2006 dollars, here’s what these company reports reveal:
+
+ExxonMobil’s total R&D spending has remained essentially flat since 1993, with barely any increase.
+Shell had the fastest growth in R&D expenditures over the past five years (out of the four companies); however, because Shell’s R&D outlays had dropped dramatically throughout the 1990s, actual gains were marginal.
+BP continues to spend less on energy R&D than either ExxonMobil or Shell. Despite dubbing itself BP or “Beyond Petroleum” in 2000, BP’s aggregate spending on all energy R&D is still roughly the same as it was a decade ago, although the company’s pledge of $50 million per year over 10 years for the Energy Biosciences Institute will lift this total slightly.
+Chevron’s aggregate spending on R&D remained extremely low and flat from 1999 through 2004. Since 2005, Chevron’s R&D outlays rose, but they still remain the lowest of the four. (see the graph for details).""" ,
+                               """Major findings—A brief synopsis
+This report’s analysis of the contracts underlying 10 large-scale university-industry alliances to finance energy research identifies eight major areas where serious limitations on academic freedom and academic research, and governing independence are permitted. What follows is a brief description of the eight areas where these agreements appear to fail to uphold the universities’ core academic and public-interest obligations:
+
+1. Do these agreements protect university independence and academic self-governance?
+In nine of the 10 agreements, the university partners failed to retain majority academic control over the central governing body charged with directing the university-industryresearch alliance. Four of the 10 alliances allow for full industry sponsor control over the alliance’s main governing body.
+
+In some cases the written agreement explicitly gives the industry sponsor or sponsors full control. In other cases, this is how the agreement is being interpreted and/or administered in practice. This finding is quite remarkable. “Academic independence” has been rooted, historically, in the university’s core belief that it must retain the ability to govern its own internal affairs. This is often referred to as “academic self-governance” or “academic autonomy.”
+
+Ever since the birth of the academic freedom movement in the early 1900s, U.S. universities and their faculties have worked strenuously to prevent outside donors (whether a wealthy benefactor, a commercial sponsor, or a federal grant-making agency) from exerting undue influence over faculty teaching, research, and other internal academic governance decisions. The rationale for this is quite straightforward: Without self-governance, research independence and free inquiry are meaningless.
+
+2. Do these agreements require faculty research proposals to be evaluated and awarded funding on the basis of impartial “peer review”?
+None of the 10 agreements requires faculty research proposals to be evaluated and awarded funding in each new grant cycle using academic methods of independent, impartial peer review. In the case of the Arizona State University-BP research alliance this question does not apply because all the research projects have been identified upfront so no other campus faculty are eligible to apply for funding.
+
+In interviews and written comments, several university officials told CAP that, even though their formal alliance agreements do not require peer review, they do frequently draw on the expertise of outside expert reviewers. Yet, in all the cases reviewed in this report, it is the view of the author and our legal experts that the use of peer review is variable, inconsistent, and/or does not rise to the level of genuine, impartial, expert peer review. And because peer review is not secured in the alliance’s legal contract, its weight in the research-selection process remains unclear, and its application can be altered or simply abandoned at any time. (For more discussion, please see the detailed contract reviews in Appendices 1-10.)
+
+Consider Stanford University’s Global Climate and Energy Project, which is funded by Exxon Mobil, General Electric, Toyota and Schlumberger. Neither of GCEP’s formal written alliance agreements (originally signed in 2002 and renewed in 2008) requires the use of expert peer review for the selection of faculty research proposals. Both agreements’ use of peer review is entirely optional and left to the discretion of the four industry sponsors. Stanford officials respond that GCEP uses an informal peer-review system even though it is not legally required, and that they posted written peer-review protocols on a public website to clarify how this peer review works in practice. But our outside legal experts say this informal peer review system is not legally binding and could be altered or abandoned at any time. (see Appendix 8 for details)
+
+Academic peer review has long been considered the gold standard when it comes to appropriately and fairly evaluating the quality and worthiness of scientific and academic research. When faculty research proposals are evaluated by independent experts using an impartial peer review process, it helps to ensure that corporate-research funding is awarded on the basis of both scientific and academic merit—not merely on the basis of one firm’s short-term business needs or the narrow strategic goals of one industrial sector.
+
+When Cornell University’s faculty senate issued final recommendations in 2005 on how best to structure large-scale, university-industry research alliances, it strongly emphasized the centrality of independent peer review: “The important point—vital to honoring the principal that we are engaged in academic, not corporate research—is that genuine, disinterested peer review occur.”
+
+3. Are these agreements fully transparent about how the faculty may apply for commercial funding, and what the methods and criteria for selection will be?
+Eight of the 10 alliance agreements fail to specify in adequate detail how faculty may apply for alliance research funding, or what evaluation and selection criteria will be used. Within the university and scientific communities it is widely understood that high standards cannot be maintained unless faculty research and scholarship is judged fairly and impartially based on academic merit and scientific excellence, not according to the narrow wishes or dictates of outside sponsors.
+
+The notable lack of clarity and transparency in a majority of these 10 university-industry agreements (combined with their failure to require peer review) suggests that funding awarded through these academic-industry alliances will strongly favor the business and strategic interests of the corporate sponsors. Given that nine of the 10 agreements also clearly state that the university side will be responsible for administering and overseeing the research-selection process (on behalf of the alliance as a whole), this could leave university leaders vulnerable to accusations that they are putting the sponsors’ commercial interests ahead of the universities’ core commitment to high-quality research, and the disinterested quest for knowledge and truth for the benefit of the public.
+
+4. Do these agreements adequately distinguish “academic research” from “corporate research for hire?”
+The answer to this question largely rests on which party to the agreement defines the alliance’s overarching research agenda, which party draws up the “request for faculty research proposals” in each new grant cycle, and which party retains majority control over the evaluation and final selection of academic research proposals. Let’s consider each of these in turn.
+
+In eight of the 10 agreements that we reviewed, the industry sponsor substantially defines the alliance’s “overarching research agenda.” (The exceptions were Arizona State University and Stanford University.) This is not unusual. No funding source is entirely neutral. Simply by defining what research questions will be asked, nearly every sponsor exerts some degree of influence over the academic research enterprise.
+
+It also is not unusual for the corporate sponsors to play a subsequent role in setting the research agenda during each new grant cycle. In five of the 10 agreements, the industry sponsors and the university partners share some responsibility for drawing up a list of research topics in each new grant cycle, and issuing the request for new faculty research proposals. In four cases, the contact allows the industry sponsors to fully set the agenda in each new grant cycle.
+
+But in eight out of 10 contracts we examined, the agreements broke significantly from longstanding university commitments to academic self-governance. This finding is the most significant one. Usually, when it comes to internal academic governance decisions—including the evaluation and selection of faculty research—the university insists on majority academic representation and the right to use independent, expert peer reviewers. In 2007, for example, a U.C. Berkeley faculty senate committee reviewing the Energy Biosciences Institute partnership stressed that all BP-EBI funded research “should not in any way be conceived of or seen as work made for hire for the benefit of the corporate sponsor.”
+
+Nonetheless, in eight of the 10 alliance agreements reviewed here, the university failed to retain majority control over the evaluation and final selection of faculty research proposals, or to require the use of impartial peer review, thus leaving the distinction between “academic research” and “corporate research for hire” quite unclear and uncertain.
+
+5. Is the university’s fundamental right to publish protected?
+Yes. Nine of the 10 agreements affirm the university’s right to publish, but in many instances this contractural right is curtailed by potentially lengthy corporate delays. The National Institutes of Health generally recommends no more than a 60-day delay on academic research publication, which it deems adequate time for the corporate sponsor to file a provisional patent application and remove any sensitive proprietary information. None of the 10 agreements analyzed abide by this maximum-60-day federally recommended publication delay; most far exceed it.
+
+One alliance agreement at the University of Colorado, Boulder and three other publicly funded research institutions in Colorado (known as the Colorado Center for Biorefining and Biofuels, or C2B2) permits the industry sponsors to delay publication for up to 210 days. Another alliance agreement at Stanford University, the Global Climate and Energy Project, gives the four sponsors a mandatory, 60-day review period to consider patent protection prior to release of any academic publications. After this, the agreement provides for no maximum delay on publications, leaving the potential, at least, for indefinite delays. A third alliance agreement with Chevron permits the sponsor to delay publication for up to one year, including student theses.
+
+The timely release of academic information is what makes the university research sphere so exceptionally vibrant, innovative, and dynamic. Rapid dissemination of new knowledge helps to insure that all scientific research is subject to independent review and replication to verify its accuracy. Research should never be quarantined; it needs to be released rapidly so others can react to it and build upon it, continually driving the pursuit of new knowledge forward.
+
+6. Does the corporate sponsor enjoy monopoly commercial rights to all the university’s sponsored-research results?
+We asked our outside legal examiners to rank each alliance agreement on a scale of 1 to 10, with 1 representing very weak contract language granting exclusive commercial rights to the industry sponsor, and 10 representing very strong language granting exclusive commercial rights. Seven of the 10 agreements ranked 8 or higher for their degree of exclusivity, thus giving the industry sponsors strong monopoly commercial control over the alliances’ sponsored research results.
+
+Seven of the 10 agreements left the university side with extremely limited power to license sponsored-research results nonexclusively to outside commercial users. But there are three notable exceptions. The first is the so-called “shared side” of the Colorado Center for Biorefining and Biofuels. The second is the alliance agreement between the University of Texas at Austin, Rice University, and ten companies. And the third is Stanford University’s Global Climate and Energy Project agreement. GCEP was originally launched in 2002, but the university and its four industry sponsors negotiated a new, revised contract in September 2008 that greatly facilitated non-exclusive licensing and open academic sharing of GCEP research results through the elimination of a 5-year, sponsor exclusivity provision. (see Appendix 8 for details)
+
+But the flip side is this: At least four of the 10 agreements (BP-Arizona State University, BP-Energy Biosciences Institute, Chevron-U.C. Davis, and Chevron-Texas A&M) explicitly permit the industry sponsors to extend the commercial rights to “background” academic research, which by definition was not funded by the industry sponsors but by public and other sources not party to the alliance agreement.
+
+Because U.S. taxpayers continue to subsidize higher education substantially through general overhead for state universities, federal and state subsidies for student tuition, graduate-student fellowships, educational tax breaks, and federal research grants, most U.S. universities pledge their commitment to patenting and licensing academic research in a manner “consistent with the public interest.” This is generally understood to mean that universities will work to maximize broad public use of their academic inventions and research tools, and prevent any one private or commercial entity from exerting excessive monopoly control, unless it is absolutely necessary to promote commercial development.
+
+Case in point: In one 2008 review of the BP-EBI alliance, a faculty senate Task Force on University-Industry Partnerships noted that “the use of exclusive licenses should be as limited as possible, given our public mission.” Such sentiments have also been affirmed by the National Institutes of Health, and by more than 50 universities that are signatories to a 2007 statement titled “Nine Points to Consider in University Licensing.”
+
+Yet in seven of the 10 contracts we examined for this report, industry sponsors are granted broad, upfront, exclusive commercial rights to alliance research—even, in some cases, when certain “background knowledge” was developed prior to the creation of the alliance and not funded by the sponsor.
+
+7. Are university faculty members free to share their sponsored-research results with other academic investigators?
+Using our 1-to-10 scale, with 1 representing very weak protections for academic use and sharing and 10 representing very strong protections, the 10 agreements earned an average ranking of just 5.5 for protecting academic use and sharing. Given how important academic sharing is to the whole university and national scientific enterprise, this is troubling.
+
+Since 2007, more than 50 U.S. research universities have endorsed a public statement listing nine core principles that all universities should be required to uphold in their licensing deals with industry. The first of these principles calls for all universities to include a provision in their industry contracts—often known as a “research exemption” —that permits professors and students to freely share their sponsored-research results (including data, tools, and methods) with outside researchers for non-commercial research purposes, including verification of published research findings.
+
+Nevertheless, only four of the 10 alliance agreements had strong academic-use and sharing provisions, receiving a rank of 7 or higher. Five of the 10 agreements ranked 5 or lower (moderate to poor) for protecting the academic investigators’ right to share sponsoredresearch with other academic scientists and scholars for purely research and non-commercial purposes, despite its centrality to the academic research enterprise.
+
+8. Are conflicts of interest adequately regulated in these university-industry alliance agreements?
+Nine of the 10 agreements fail to discuss the management of financial conflicts of interest related to the alliance and its research functions. The lone exception is Stanford University’s Global Climate and Energy Project, where the agreement mentions the need to manage conflicts of interest only with regard to optional peer review panels (convened at the discretion of the industry sponsors) and third-party university grant recipients. This latter reference, however, was dropped from GCEP’s, revised 2008 agreement.
+
+None of the 10 agreements prohibit members who sit on the alliances’ main governing body from having personal financial interests related to the research they are charged with overseeing and directing. At the BP-Arizona State University alliance there is no formal governing body so this question does not apply.
+
+Similarly, none of the 10 agreements prohibits committee members charged with evaluating and selecting faculty research proposals from having financial conflicts of interest related to the research they are reviewing. Again, the lone exception is Stanford’s Global Climate and Energy Project, where the agreement states that peer review panels must be free of conflicts, but these panels are optional, and used solely at the discretion of the management committee members, where the industry sponsors control all the votes.
+
+Furthermore, none of the 10 agreements specifies that these committee members may not award commercial research funding to themselves, or their own labs. This type of potential conflict has already surfaced as a widespread problem at the BP-funded Energy Biosciences Institute administered by U.C. Berkeley. Specifically, after the EBI deal was finalized at the end of 2007, U.C. Berkeley’s press office announced that the executive committee charged with evaluating faculty research projects for possible BP funding would have strong majority academic representation. And when the first formal executive committee convened in 2008 it had eight members, seven of whom were academics and one of whom was a representative from BP. But when this report’s author probed a bit deeper, she soon found that seven of these eight committee members had significant potential conflicts of interest, including all but one of the academics.
+
+Two of the eight executive committee members, including the EBI’s Academic Director and the lone BP representative, had financial ties to firms that could stand to profit from the EBI’s academic research. And five of the other committee members had a different potential conflict: All were listed on the EBI website, in the spring of 2008, as “primary investigators” on research projects funded by BP-EBI. What this strongly suggests is that all five could award BP research grant money to themselves and their labs. At the very least, the application and receipt of BP-EBI funding calls into question whether these faculty members were capable of fairly and impartially evaluating other faculty research proposals.
+
+More recently, these potential conflicts of interest on the EBI’s executive committee seem to have only worsened. As of September 2010, the EBI listed a total of 13 executive committee members: 11 academics and two representatives from BP. Yet 10 of these academics are also listed as primary EBI investigators or heads of projects supported with BP-EBI funding, and one, EBI Director Chris Somerville, continues to have personal financial interests in an outside firm partnering with BP on research that is similar to that of EBI. That means three of the executive committee’s 13 members have financial ties to firms that could profit from EBI research, and the other 10 are academic researchers who have vested research and financial interests with the EBI that could compromise their ability to evaluate incoming faculty research in an impartial and disinterested manner, based on scientific merit (for more details, see the box on conflicts of interest on page 64).""" ,
+                               """Methodology used for reviewing the 10 agreements
+To better understand the specific contractual requirements underlying each of these university-industry research alliances, we turned to Professor Sean O’Connor, a noted legal scholar at the University of Washington Law School with expertise in intellectual property law and university-industry contracting, and Jeremiah Miller, his former graduate assistant and now a practicing attorney in Seattle. O’Connor is Director of the Law, Technology and Arts Group at the University of Washington School of Law. He provides private legaland IP-consulting assistance to many universities, nonprofits and for-profit organizations. Miller performed the primary analysis and interpretation of the contracts. O’Connor then reviewed his analysis. Their services were provided in a personal capacity. They do not necessarily endorse the conclusions of this report.
+
+All the “academic benchmarks” used in our review of the 10 agreements were drawn from a set of detailed analyses of Strategic Corporate Alliances, or SCAs, on campus, developed by a prominent faculty-senate committee at Cornell University from 2004 to 2005.35 Most of the 10 agreements reviewed here broadly fit Cornell’s definition of a Strategic Corporate Alliance: “a comprehensive, formally managed company-university agreement centered around a major, multiyear, financial commitment involving research, programmatic interactions, intellectual property licensing, and other services.”36 Academic norms and public-interest commitments are not well codified in any single document, but they are frequently referred to and affirmed in university mission statements, faculty senate documents such as Cornell’s SCA review, and statements and reports issued by government funding agencies and prominent university associations, including the Association of American Universities, Association of American Medical Colleges, and American Association of University Professors.
+
+This report’s author used the Cornell SCA analyses and their SCA management recommendations as the basis for developing a list of 17 Review Questions to structure this report’s legal contract review. As such, the legal review is not from a purely business standpoint (since most legal contracts are assumed to involve two business entities) but rather from the standpoint of widely accepted academic norms and public-interest benchmarks, including the need to safeguard the university’s core academic mission, and its commitment to self-governance, independent research, and the dissemination of high-quality, reliable, public knowledge.
+
+With regard to the intellectual property provisions in these agreements, our outside legal experts were asked to rank each agreement on a scale of 1 to 10 to assess the amount of exclusive commercial control over academic research results that each agreement permits the industry sponsors, as well as the degree of flexibility afforded to the university partners (and faculty) to license discoveries nonexclusively and/or to share research with other academics. Knowledge sharing is widely seen as a fundamental duty of all academics, as detailed in “Nine Points to Consider in Licensing University Technology,” a 2007 statement signed by more than 50 universities, and other federal agency guidelines.37 It should be noted that our external legal reviewers’ scored rankings for several of the Contract Review Questions are necessarily subjective because interpretations of law and other intellectual property terms cannot be strictly quantified. Moreover, to the author’s knowledge, these contracts have not been tested in a court of law, so their “legal meaning” has not been definitively elaborated.
+
+The first round of legal reviews were completed in the summer of 2008. In July 2010, CAP invited the universities heading up these 10 alliances to provide written comments on the major contract findings, and any contract updates. Seven of the 10 universities provided feedback, two did not respond to our request, and one, Texas A&M University, requested permission from the state attorney general to deny our request for information relating to its Chevron alliance. To the best of our knowledge, the contract analyses in Appendices 1-10 beginning on page 75 are current.
+
+Many university administrators, in their comments and interviews, raised objections to this report’s reliance on written contracts, noting the existence of other academic customs, campus-wide policies, and procedures and practices developed outside of the written contracts. Many of these administrators also objected to the report’s predominant focus on academic and public-interest benchmarks to rate the contracts, arguing there also is an academic and public interest in drawing private-sector money and expertise into the research and development of alternative energy technologies. They felt this view was not sufficiently addressed in the analysis of their contracts as presented in our major contract findings at the time of their review. These comments from university administrators are presented in the individual appendices beginning on page 75 and are taken into account when germane in the appendices and the main body of the report.
+
+Still, these legal agreements constitute the primary, if not the only, legally binding authority between the parties. Anything that is left up to informal practices and generalized policy is subject to alteration and inconsistent application, and may not be legally binding. Written contacts also enhance accountability, and engender public trust. Thus the focus of this report on the contracts themselves as the basis of the report’s analysis.""" ,
+                               """Nevertheless, this redirection of industry R&D dollars to U.S. universities is significant. The reasons: A sizable portion of this university funding is now being directed to “alternative energy research” (especially biofuels), and this shift in the allocation of industry resources has the potential to significantly influence the academic research culture in this new energy arena.
+
+These investments in clean energy research by leading energy companies also appear to be part of the energy industry’s current campaign to project a more pro-environmental public image. Turn on the TV or open virtually any magazine and you’re likely to see an ad from a major oil, coal, gas, auto, agriculture, or other company touting its commitment to the research and development of clean-energy technologies: biofuels, “clean coal” technology, hydrogen fuel cells. Not infrequently, these “green ads” explicitly reference the industry’s multimillion-dollar alliances with U.S. universities, whose prestige and public trust are an added selling point (see box).""" ,
+                               """Recommendations for the U.S. government
+Launch an “Apollo Project” for clean-energy, climate, and efficiency R&D with strong academic and public-interest safeguards
+In 2009, for the first time in several decades, the U.S. Congress significantly boosted energy R&D spending. When both stimulus money and appropriations funding are included, the 2009 Department of Energy budget for R&D bounced 68 percent (over 2008 funding levels) to $16.3 billion, with the largest portions going to Basic Science ($6.1 billion) and Energy R&D ($6.4 billion), and the remainder ($3.8 billion) going to DOE defense-related research. Of this, roughly $3.95 billion is slated for Energy Efficiency and Renewables R&D specifically. Such investments must continue. It is time for the U.S. government to launch a major new initiative to finance cutting-edge research in clean energy and energy efficiency at U.S. universities on the scale of past federal science programs, such as the Apollo and Manhattan projects.
+
+Before the U.S. government invests in additional R&D, however, it should develop “standard contract language” attached to every federal research grant for universities that obligates the university to uphold certain core academic and public interest obligations—no matter whether this funding comes via the federal government alone, or in combination with corporate matching grants.
+
+Require all federal energy grants be issued using expert peer review
+Renewed U.S. investment in energy-related R&D should be accompanied by a standard federal contract that requires use of impartial expert peer review by all federal, university, and private industry research partners. Allocating federal science funding through an independent, scientific peer-review process is the only way to ensure that taxpayer grants are awarded on the basis of true scientific merit. Use of independent expert peer-review should also be stipulated in all academic-industry-government R&D alliance agreements.
+
+Allocate sufficient funds for fundamental, pre-commercial science and other vital public-good research
+The federal government likes the idea of using public-private partnerships to maximize the economic impact of public science spending. And certainly using government R&D funding to leverage (and also stimulate) industry R&D spending can be a “win-win” combination. But public-good research should involve more than the pursuit of technologies with the potential for near-term commercialization. As transportation expert John DeCicco at the University of Michigan explains: “Ultimately, public-good research needs to be directed toward achieving critical public-good outcomes such as lowering global greenhouse gas emissions in the near term, not just the development of new technologies.” Academic expertise is urgently needed to tackle a broad array of public interest problems, and also to advance public knowledge and understanding.""" ,
+                               """Recommendations to U.S. universities
+This report also offers recommendations on how to sustain America’s vibrant public research infrastructure, and our universities’ commitment to high-quality, disinterested, public-good energy research. Here, we briefly summarize these recommendations.
+
+Police commercial conflicts of interests
+U.S. universities must not allow their quest for research revenue or, increasingly, their quest for earnings from the transfer and commercialization of academic research, to distort their core academic and public-knowledge functions. Industry relationships and other commercial activities on campus should not compromise the universities’ fundamental commitment to the pursuit of truth, impartial inquiry, and public-good knowledge.
+
+This is not to say that U.S. universities and their faculties should disregard the potential commercial applications of their academic research and discoveries. Not at all. But universities need to make a far more vigorous effort to oversee and, whenever possible, eliminate financial conflicts of interest on campus (both at the faculty and at the institutional levels) to preserve their scientific and academic integrity, research independence, and public trust. This process, too, could be vastly aided by stronger federal conflict-ofinterest guidelines attached to federal research grants.
+
+Maximize faculty involvement in the design and oversight of large-scale corporate-research alliances
+University faculty, through their main governing body—the academic or faculty senate—should be fully involved in the planning, execution, and monitoring of any large-scale, academic-industry research alliances proposed on campus. These large, multi-year corporate-research alliances tend to have a broad impact on the whole academic institution, due to their size, duration, and potential influence on the public perception of the institution compared to more common, smaller industry-sponsored research agreements. As such, they warrant far greater faculty-senate involvement in their initial design, formation, and subsequent oversight. This will also engender greater campus support and public trust through enhanced transparency.
+
+Safeguard academic autonomy
+To protect the American university’s valuable traditions of self-governance and research independence, academic representatives (not industry representatives) should retain strong (preferably two-thirds) majority representation and voting power on any academic governance bodies that are charged with overseeing or administering university-industry research alliances on campus. Equal distribution of voting power is not sufficient, because it does not protect the university’s tradition of self-governance and research autonomy.
+
+Retain academic control over research selection and the use of independent expert peer review
+University representatives should retain majority representation (and voting power) on any academic body that is charged with evaluating faculty research proposals, and/or making final research awards, as part of any large-scale, multiyear, university-industry research alliance. Faculty research proposals should also always be evaluated using independent expert peer review so research excellence, not merely narrow commercial preferences or profit criteria, guide the academic selection process. And experts selected to judge faculty research proposals should never be in a position to derive any financial benefit from the alliance (or its corporate sponsors). They should remain free of personal financial interests that could in any way bias or prejudice their evaluations.
+
+Minimize delays on publication
+U.S. universities should not permit their industry sponsors to delay publication for longer than 60 days, which the National Institutes of Health and other federal agencies deem sufficient time for the commercial sponsor to file for provisional patent protection and remove any sensitive corporate proprietary information. Publication is an academic principle that helps ensure the rapid diffusion of public knowledge, which is independently scrutinized and verified for accuracy.
+
+Protect academic knowledge sharing
+Any university that enters into a large-scale industrial research alliance should include a legal clause—known as a “research exemption” or “academic-use exemption”—as part of its licensing agreement with the corporate sponsor. This “exemption” permits all university professors to freely share their sponsored-project results (related to any published academic research) with other scientists, both within their own academic institution and at other non-profit and governmental institutions, for purely non-commercial, research purposes. Too many schools continue to overlook this critical knowledge-sharing function even though it is the first principle enshrined in a 2007 academic statement titled “In the Public Interest: Nine Points to Consider in Licensing University Technology,” endorsed by more than 50 universities.
+
+Resist monopoly ownership of academic knowledge
+Researchers rely on the wellspring of shared academic knowledge to stimulate their own creativity, research, and scientific and technological discovery. Over the past several decades, in an effort to extract rents from campus-based research, U.S. universities have imposed proprietary restrictions on a growing share of this academic research. Because U.S. universities remain heavily reliant on U.S. taxpayer support for their research-anddevelopment funding, it is important for these academic institutions to resist the temptation to grant their corporate sponsors exclusive, monopolistic control over the universities’ academic research, most of which is heavily subsidized by public sources. To the greatest extent possible, U.S. universities should license the bulk of their research nonexclusively so it may be used by multiple parties in diverse research and commercial applications.
+
+Together, these sets of recommendations to the federal government and universities would help both private industry and the American public by preserving a vibrant, highquality, public research sector. The analysis of these 10 university-industry research contracts alongside our observations and recommendations can help the Obama administration and Congress as they consider new measures, such as national limits on carbon pollution, a Clean Energy Technology Fund, and other programs to stimulate sustainable energy and clean energy technologies. By ensuring that the balance in these collaborative research efforts tilts strongly in favor of academic independence, the administration and Congress have a rare opportunity to restore this vital balance between our public and private research sectors. Our energy security, global environment, and economic competitiveness all hang in the balance.""" ,
+                               """The answers to these three questions are critical to energy-related research and development in our country, given the current global-warming crisis and the role that academic experts have traditionally played in providing the public with impartial research, analysis, and advice. To unpack these questions and help find answers, this report provides a detailed examination of 10 university-industry agreements that together total $833 million in confirmed corporate funding (over 10 years) for energy research funding on campus. Copies of these contractual agreements were obtained largely through state-level public record act requests (see the table on pages 13 and 14 for a list of these 10 agreements, and see page 15 for the methodology used for obtaining and analyzing them). Each agreement spells out the precise legal terms, conditions, and intellectualproperty provisions that govern how this sponsored research is carried out by the faculty and students on campus. (See methodology on page 15 for a discussion of how practices that are not required in these conflicts fit into the analysis.)
+
+Independent, outside legal experts then performed a detailed analysis of each agreement. These experts’ detailed contract reviews may be found in Appendices 1 through 10 beginning on page 75 of this report, and include responses from a number of the universities that entered into these agreements. It should be noted that our external reviewers’ rankings for several of the “Contract Review Questions” are subjective because interpretations of law and other intellectual property terms cannot be strictly quantified. Also, the provisions in these contracts have not to our knowledge been tested in a court of law, so their “legal” meaning has not been definitively established.
+
+The results of this report’s analysis of these 10 large-scale university-industry contracts raise troubling questions about the ability of U.S. universities to adequately safeguard their core academic and public-interest functions when negotiating research contracts with large corporate funders. This report identifies eight major areas where these contracts leave the door open to serious limitations on academic freedom and research independence. Here are just a few brief highlights:""" ,
+                               """The world’s largest oil companies are showing surprising interest in financing alternative energy research at U.S. universities. Over the past decade, five of the world’s top 10 oil companies—ExxonMobil Corp., Chevron Corp., BP PLC, Royal Dutch Shell Group, and ConocoPhillips Co.—and other large traditional energy companies with a direct commercial stake in future energy markets have forged dozens of multi-year, multi-million-dollar alliances with top U.S. universities and scientists to carry out energy-related research. Much of this funding by “Big Oil” is being used for research into new sources of alternative energy and renewable energy, mostly biofuels.
+
+Why are highly profitable oil and other large corporations increasingly turning to U.S. universities to perform their commercial research and development instead of conducting this work in-house? Why, in turn, are U.S. universities opening their doors to Big Oil? And when they do, how well are U.S. universities balancing the needs of their commercial sponsors with their own academic missions and public-interest obligations, given their heavy reliance on government research funding and other forms of taxpayer support?""" ,
+                               """To our knowledge, this report represents the first time independent analysts have systematically examined a set of written university-industry agreements within a specific research area—in this case, the energy R&D sector—to evaluate how well they balance the goals of the corporate sponsors to produce commercial research that advances business profits with the missions of American universities to perform high-quality, disinterested academic research that advances public knowledge for the betterment of society.
+
+Before Congress releases billions of dollars in much-needed federal funding for more research and development of alternative and renewable energy and energy efficiency via direct grants and other public-private partnerships, it should give careful consideration to the findings and recommendations made in this report. Indeed, this analysis could not be more timely. As proposals to put a cap and price on carbon pollution circulated earlier this in Congress, most major oil companies, including their main lobby, the American Petroleum Institute, continue to vigorously oppose any such carbon caps by running millions of dollars’ worth of negative ads warning the public and politicians of the dire consequences of action. But whenever comprehensive energy legislation is finally implemented, then a significant portion of the funds generated through cap-and-trade legislation will likely be targeted toward efficiency and clean-energy R&D performed by academic experts at U.S. universities.
+
+What’s more, these funds will likely be disbursed through a variety of public-private research partnerships similar to the ones examined in this report. In recent years the U.S. Department of Energy and other federal agencies have shown a strong preference for disbursing federal research dollars through public-private cost-sharing arrangements. According to Doug Hooker, the director of renewable energy at the DOE’s Golden Field Office in Colorado (which handles grant making for DOE’s Office of Energy Efficiency and Renewable Energy), roughly 80 percent to 90 percent of the federal research money that now goes to finance renewable-energy and efficiency R&D is disbursed through some form of public-private cost-sharing arrangement.
+
+Usually, says Hooker, the corporate beneficiary of this DOE research funding is asked to provide a 20 percent to 50 percent matching grant, depending on the stage of the research project and its proximity to commercial application. “We are leveraging the available dollars that are out there in the private sector,” Hooker said in an interview. “We believe it helps with the success rate and the industry’s commitment to these technologies.”
+
+Yet the long-term effectiveness of this strategy remains unknown. John DeCicco, an expert on transportation and a senior lecturer in the School of Natural Resources and the Environment at the University of Michigan, remains skeptical. “The whole concept of using tax dollars in public-private arrangements needs much better scrutiny,” he argues. “This strategy inherently threatens the essence of public-good research, and can blur the boundary lines between independent invention and analysis on the one hand, and strictly commercial R&D on the other.”
+
+U.S. universities, of course, have long relied on a combination of federal government and industry grants to finance their research operations. U.S. academic institutions spent $52 billion on research and development in 2008, the last year for which complete data were available, with about 60 percent financed by U.S. taxpayers through a variety of federal grant-making agencies. Nationally, though, only about 6 percent of university research overall is funded by industry.
+
+Nevertheless, according to some estimates, because of the federal government’s growing preference for allocating federal R&D funds through corporate matching grants and other cost-sharing and cooperative-research arrangements, private industry now directly influences anywhere from 20 percent to 25 percent of university research funding overall. In this way, a significant share of U.S. taxpayer funding that starts out as “public” funding is effectively turned “private” by the time it reaches the university investigators in their academic labs.
+
+Top Obama administration officials, including Energy Secretary Steven Chu and Undersecretary for Science at the Department of Energy Steven E. Koonin, are strong supporters of using industry-university-government partnerships to advance clean-energy R&D. In 2007, prior to joining the administration, both Chu and Koonin were instrumental in brokering a $500 million research collaboration (discussed in detail in this report) between the British oil giant BP PLC and three major U.S. taxpayer-financed research institutions: the University of California at Berkeley, the University of Illinois at Urbana-Champaign, and Lawrence Berkeley National Laboratory, a federal research lab managed by U.C. Berkeley. At the time, Chu, a Nobel Prize-winning scientist, was director of Lawrence Berkeley, and Koonin was serving as BP’s chief scientist.
+
+By academic standards, these multiyear, multimillion-dollar industry investments on campus certainly look huge. Yet relative to the oil industry’s vast profit margins, this R&D spending remains infinitesimally small. Consider BP’s 10-year, $500 million investment in the Energy Biosciences Institute at U.C. Berkeley, which is primarily dedicated to researching biofuels. Relative to BP’s profit margins, this mega-size university deal represents little more than a drop in the proverbial bucket. Let’s begin by conservatively estimating that BP’s average business performance from 2006 to 2015 will remain roughly on a par with its 2003-2007 performance. During this time period, BP’s average revenues were $233 billion, and its average profits hit $19.2 billion. If such trends continue, and excluding any significant hit to BP’s bottom line due to the consequences of the 2010 oil catastrophe in the Gulf of Mexico, then:""" ,
+                               """What do the 10 contractual agreements tell us?
+Now let’s turn to the centerpiece of this report: the university-industry-research agreements themselves. The central analysis that underpins this report, and the questions it raises, is drawn from a comprehensive analysis and independent expert level review of 10 recent alliance agreements among as many as 43 companies (some contracts boast fluctuating membership), 13 leading universities, and two federal research labs, totaling $833 million in confirmed industry funding over ten years.
+
+Most of the copies of the 10 agreements were obtained through public record act requests filed with state-funded universities (although these often proved extremely time-consuming and difficult to obtain because many state-funded institutions stalled or outright refused our requests). Several were also obtained from academic administrators through personal phone requests, or had been previously made public. Private universities are not required to (and usually do not) publicly disclose their contract research agreements with industry. Stanford University made a rare exception when it chose to publicly disclose its contract with ExxonMobil and three other companies following campus pressure to do so (see table below for a complete list of the 10 agreements analyzed and the accompanying box on page 15 for an explanation of the methodology we employed).""" ;
+                         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                         dct:created "2025-01-30T04:41:59Z"^^xsd:dateTime ;
+                         rdfs:label "Big Oil Goes to College" ;
+                         :url <https://www.americanprogress.org/article/big-oil-goes-to-college/> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Brazil
+:Brazil rdf:type owl:NamedIndividual ,
+                 :Nation ;
+        <https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn> :South_America ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-30T02:53:31Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Brown_University
+:Brown_University rdf:type owl:NamedIndividual ,
+                           :University ;
+                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                  dct:created "2025-01-29T18:22:44Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Chile
+:Chile rdf:type owl:NamedIndividual ,
+                :Nation ;
+       <https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn> :South_America ;
+       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+       dct:created "2025-01-30T02:53:39Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Climate_Obstruction_in_Europe
+:Climate_Obstruction_in_Europe rdf:type owl:NamedIndividual ,
+                                        :Book ;
+                               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                               dct:created "2025-01-29T00:45:54Z"^^xsd:dateTime ;
+                               rdfs:label "Climate Obstruction in Europe" ;
+                               :url <https://cssn.org/news-research/europe-volume/> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Climate_Obstruction_in_the_United_Kingdom
+:Climate_Obstruction_in_the_United_Kingdom rdf:type owl:NamedIndividual ,
+                                                    :Book_Chapter ;
+                                           :has_author :FREDDIE_DALEY ,
+                                                       :JAMES_PAINTER ,
+                                                       :PETER_NEWELL ,
+                                                       :RUTH_MCKIE ;
+                                           dct:abstract """United Kingdom
+Despite widespread public backing for the UK’s legally binding goal of reaching net zero emissions by 2050 and the economic benefits it could bring, climate obstructionists deploy a variety of tactics and strategies to maintain dependence on volatile and dangerous fossil fuels.
+
+Key actors:
+Organised sceptic groups and think tanks (e.g. Global Warming Policy Foundation, Net Zero Watch), media (particularly right-leaning papers such as The Daily Telegraph and The Daily Mail), business and trade associations (e.g. CBI), government actors and institutions.
+
+Tactics:
+Media campaigns: Outlets such as The Daily Telegraph often publish editorials and opinion pieces promoting climate obstructionism.
+Lobbying and political influence: Fossil fuel companies directly lobby elected politicians to shape policy in their favour and fend off tighter regulation. This influence is enabled by donations to political parties and revolving doors and secondments to government.
+Key messages:
+Economic cost: Framing climate policies as ‘a risk to the economy’, ignoring the more significant financial costs to the public resulting from slow progress on climate action.
+Undermine renewables: Climate obstructionists cast doubt on the reliability and cost of renewable sources like solar and wind power, despite evidence that in the UK renewables are significantly cheaper than gas.""" ;
+                                           dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                           dct:created "2025-01-29T18:33:01Z"^^xsd:dateTime ;
+                                           rdfs:label "Climate Obstruction in the United Kingdom" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Coolglass_Windfarm_Limited_v_An_Bord_Pleanala
+:Coolglass_Windfarm_Limited_v_An_Bord_Pleanala rdf:type owl:NamedIndividual ,
+                                                        :Litigation ,
+                                                        :Web_Page ;
+                                               :has_jurisdiction :High_Court_of_Ireland ,
+                                                                 :Ireland ;
+                                               :has_status :Decided ;
+                                               :at_issue "Whether public bodies had a duty under domestic climate legislation, EU law and European human rights law to give due consideration to climate objectives in determining whether to grant planning permission for renewable energy infrastructure projects that otherwise raised local visual concerns." ;
+                                               :summary """The case concerned an application by a wind farm company for planning permission to construct a wind farm in Co. Laois. An Bord Pleanála (the national planning authority) rejected permission for the wind farm, citing visual impacts and local development plan designations for wind turbines. Under the local Laois County Development Plan, wind farms would not be constructed in the relevant area based on the alleged visual concerns. Still, as the national planning authority, An Bord Pleanála could grant permission for the wind farm regardless of any alleged material contravention of the County Development Plan. In this instance, however, the planning permission was refused in line with the visual concerns outlined in the original County Development Plan.
+
+The company sought to appeal the decision before the High Court, arguing inter alia that under S15(1) of the Climate Act, as well as in line with EU law and obligations under the European Convention on Human Rights, the planning authority had an obligation to interpret its planning decisions such that climate considerations would take priority over the visual concerns and that the authority had therefore taken inadequate account of S15(1) of the Climate Act. The planning authority argued in response that a narrow interpretation of this provision was appropriate, obliging the authority only to give regard to climate considerations and that the authority had, therefore, acted within its powers in refusing permission for the wind farm.
+
+The High Court, in a ruling by Humphreys J. upheld the appeal, finding that An Bord Pleanála had acted unlawfully by failing to exercise its powers in a manner compliant as far as practicable with the climate objectives and policies set out in the Climate Act, and had also breached its duties under EU law and European human rights law. The Court noted that \"if climate goals take precedence over visual impacts [as had been found in a previous case of Nagle View Turbine Aware Group v. An Bord Pleanála [2024] IEHC 603 (Unreported, High Court, 1st November 2024)] and the like, then logically they must take precedence over development plan provisions that are motivated by visual impacts.”
+
+The High Court further noted that the recent European Court of Human Rights (ECHR) decision in KlimaSeniorinnen v. Switzerland demonstrated that the requirement to read legislation in an ECHR-compliant manner supported an interpretation of S15 that went beyond the board’s approach and that the interpretation should ensure that ECHR obligations are complied with in practice, including compliance in practice with stated goals in relation to renewable energy infrastructure. The failure to properly consider the climate benefits of allowing the project, therefore, constituted a breach of Article 8 of the European Convention on Human Rights.
+
+Taking the importance of climate action into account, the Court held that the authority had not adequately considered S15(1) in its considerations of whether to grant permission in light of the need to consider climate objectives in contrast to the visual impacts and local planning concerns expressed by those opposed to the wind farms. It stated that \"the need for an imperative reading of S15(1) in line with what it says, namely that the board and any other relevant body is required to act in conformity with the climate plans and objectives set out in the subsection unless it is impracticable to do so.\" [117]
+
+The Court, therefore, granted the appeal and ordered that the application be remitted to An Bord Pleanála for further consideration in accordance with the judgment.""" ;
+                                               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                               dct:created "2025-01-29T22:05:57Z"^^xsd:dateTime ;
+                                               rdfs:label "Coolglass Windfarm Limited v. An Bord Pleanala [2025] IEHC 1" ;
+                                               :url <https://climatecasechart.com/non-us-case/coolglass-windfarm-limited-v-an-bord-pleanala-2025-iehc-1/> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Decided
+:Decided rdf:type owl:NamedIndividual ,
+                  :Status ;
+         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+         dct:created "2025-01-29T22:17:33Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Europe
+:Europe rdf:type owl:NamedIndividual ,
+                 :Continent ;
+        dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+        dct:created "2025-01-31T02:40:58Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/FREDDIE_DALEY
+:FREDDIE_DALEY rdf:type owl:NamedIndividual ,
+                        <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+               :first_name "FREDDIE" ;
+               :last_name "DALEY" ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-29T18:36:40Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/High_Court_of_Ireland
+:High_Court_of_Ireland rdf:type owl:NamedIndividual ,
+                                :Court ;
+                       <https://w3id.org/semanticarts/ns/ontology/gist/hasPhysicalLocation> :Ireland ;
+                       dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                       dct:created "2025-01-30T02:58:58Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Introduction_The_First_Portrait_of_Climate_Obstruction_across_Europe
+:Introduction_The_First_Portrait_of_Climate_Obstruction_across_Europe rdf:type owl:NamedIndividual ,
+                                                                               :Book_Chapter ;
+                                                                      <https://w3id.org/semanticarts/ns/ontology/gist/isPartOf> :Climate_Obstruction_in_Europe ;
+                                                                      :has_author :J_TIMMONS_ROBERTS ,
+                                                                                  :ROBERT_J_BRULLE ;
+                                                                      dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                                      dct:created "2025-01-29T00:46:51Z"^^xsd:dateTime ;
+                                                                      rdfs:label "Introduction The First Portrait of Climate Obstruction across Europe" ;
+                                                                      :url <https://cssn.org/news-research/europe-volume/> .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Ireland
+:Ireland rdf:type owl:NamedIndividual ,
+                  :Nation ;
+         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+         dct:created "2025-01-30T02:54:01Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/JAMES_PAINTER
+:JAMES_PAINTER rdf:type owl:NamedIndividual ,
+                        <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+               :first_name "JAMES" ;
+               :last_name "PAINTER" ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-29T18:41:19Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/J_TIMMONS_ROBERTS
+:J_TIMMONS_ROBERTS rdf:type owl:NamedIndividual ,
+                            <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+                   :is_employee_of :Brown_University ;
+                   :first_name "J." ;
+                   :last_name "ROBERTS" ;
+                   :middle_name "TIMMONS" ;
+                   dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                   dct:created "2025-01-29T00:52:09Z"^^xsd:dateTime ;
+                   <http://www.w3.org/2004/02/skos/core#definition> """J. Timmons Roberts is the Ittleson Professor of Environmental Studies
+and Sociology at Brown University and the executive director of the
+Climate Social Science Network (CSSN). His current research focuses
+on social drivers of action and inaction on climate change""" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/North_America
+:North_America rdf:type owl:NamedIndividual ,
+                        :Continent ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-31T02:40:26Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/PETER_NEWELL
+:PETER_NEWELL rdf:type owl:NamedIndividual ,
+                       <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+              :first_name "PETER" ;
+              :last_name "NEWELL" ;
+              dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+              dct:created "2025-01-29T18:38:10Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Pending
+:Pending rdf:type owl:NamedIndividual ,
+                  :Status ;
+         dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+         dct:created "2025-01-29T23:52:21Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/RCC_Ruling_on_Chiquita_climate_neutral_bananas
+:RCC_Ruling_on_Chiquita_climate_neutral_bananas rdf:type owl:NamedIndividual ,
+                                                         :Selective_Disclosure ;
+                                                <https://w3id.org/semanticarts/ns/ontology/gist/containedText> "At Issue: Whether Chiquita's advertising of its bananas as \"CO2 neutral\" was misleading." ,
+                                                                                                               """Filing Date: 2022
+Reporter Info: 2022/00296
+Status: Decided
+Case Categories:
+Suits against corporations, individuals  Corporations  Misleading advertising
+Jurisdictions:
+Netherlands  Reclame Code Commissie (RCC)
+Principal Laws:
+Netherlands  Code for Environmental Advertising  Article 2""" ,
+                                                                                                               """Summary:
+The contested advertising concerned a sticker on Chiquita's bananas which included the statement \"CO2 Neutral.\" The complaint alleged that Chiquita's \"CO2 Neutral\" claim was not true. Several statements were pointed out on Chiquita's website which referred to CO2 emission reduction by 30 percent by the end of 2030. The Commission found the sticker on the bananas with the claim \"CO2 Neutral\" to be misleading pursuant to article 2 of the Code for Environmental Advertising (MRC), as it did not contain any reference to information about the interpretation of this claim. Because any context was lacking, the meaning of this claim was unclear to the average consumer. The Committee noted that the meaning of the environmental claim had had to be made clear in the advertisement. The Committee found it insufficient that the meaning of \"CO2 Neutral\" was clarified on a separate website. It also noted that the mere mention of a website was insufficient to make the meaning of the claim clear. Because the claims were admissible on the basis of the foregoing, the Committee did not have to examine the question whether Chiquita was able to demonstrate the correctness of its absolute environmental claim pursuant to article 3 MRC. However, the Committee did refer to the strict standards set out in previous rulings.""" ;
+                                                <https://w3id.org/semanticarts/ns/ontology/gist/isRecordedAt> "2022-01-01T00:00:00"^^xsd:dateTime ;
+                                                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                dct:created "2025-01-22T04:30:29Z"^^xsd:dateTime ;
+                                                rdfs:label "RCC Ruling on Chiquita “climate neutral bananas”" .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/ROBERT_J_BRULLE
+:ROBERT_J_BRULLE rdf:type owl:NamedIndividual ,
+                          <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+                 :first_name "ROBERT" ;
+                 :last_name "BRULLE" ;
+                 :middle_name "J." ;
+                 dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                 dct:created "2025-01-29T00:48:16Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/RUTH_MCKIE
+:RUTH_MCKIE rdf:type owl:NamedIndividual ,
+                     <https://w3id.org/semanticarts/ns/ontology/gist/Person> ;
+            :first_name "RUTH" ;
+            :last_name "MCKIE" ;
+            dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+            dct:created "2025-01-29T18:40:04Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/South_America
+:South_America rdf:type owl:NamedIndividual ,
+                        :Continent ;
+               dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+               dct:created "2025-01-31T02:40:07Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/USA
+:USA rdf:type owl:NamedIndividual ,
+              :Nation ;
+     <https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn> :North_America ;
+     dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+     dct:created "2025-01-31T02:52:02Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/United_Kingdom
+:United_Kingdom rdf:type owl:NamedIndividual ,
+                         :Nation ;
+                <https://w3id.org/semanticarts/ns/ontology/gist/isGeoContainedIn> :Europe ;
+                dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                dct:created "2025-01-31T02:52:16Z"^^xsd:dateTime .
+
+
+###  https://www.michaeldebellis.com/climate_obstruction/Federal_Public_Prosecutor’s_Office_v_Érico_Batista_de_Souza
+<https://www.michaeldebellis.com/climate_obstruction/Federal_Public_Prosecutor’s_Office_v_Érico_Batista_de_Souza> rdf:type owl:NamedIndividual ,
+                                                                                                                           :Litigation ,
+                                                                                                                           :Web_Page ;
+                                                                                                                  :has_status :Pending ;
+                                                                                                                  :at_issue "Whether a Brazilian farmer can be held responsible for climate and environmental damages resulting from deforestation in the Amazon." ;
+                                                                                                                  :summary """In September 2021, the Federal Public Prosecutor's Office (MPF) filed a Public Civil Action (ACP) against Érico Batista de Souza for deforesting 809.56 hectares between 2014 and 2020 in Boca do Acre, Amazonas. The MPF alleges that the defendant unlawfully occupied land within an Agroextractivist Settlement Project (PAE), federal property managed by the National Institute for Colonization and Agrarian Reform (INCRA) and occupied by traditional extractivist communities. This ACP is one of 22 actions brought by the MPF following an investigation under Civil Inquiry No. 1.13.000.001719/2015-49 into illegal deforestation in the Antimary Agroextractivist Settlement Project, though involving different defendants.
+
+The MPF bases its legal arguments on Brazilian Environmental Law, emphasizing constitutional protections for the environment, civil liability propter rem for environmental damages (including climate-related damages), and collective moral damages. The MPF also highlights the environmental liability associated with unauthorized greenhouse gas (GHG) emissions from deforestation, estimated at 510,046.20 tons of carbon dioxide. These emissions allegedly contribute to Brazil’s deviation from its climate goals, violating the National Policy on Climate Change (Federal Law 12,187/2009) and the Paris Agreement.
+
+The ACP includes the following key requests: (i) reversal of the burden of proof from the outset; (ii) immediate cessation of activities causing ongoing damage; (iii) restoration of the environment to its original state or, alternatively, payment of compensation aimed at environmental restitution; (iv) compensation for interim and residual environmental material damages; (v) compensation for climate-related damages; and (vi) compensation for collective moral damages.
+
+In March 2022, the defendant submitted a defense, denying responsibility for the deforestation and disputing the existence of collective moral damages. The defendant requested the dismissal of the action.""" ;
+                                                                                                                  dct:contributor <https://orcid.org/0000-0002-8824-9577> ;
+                                                                                                                  dct:created "2025-01-29T23:55:13Z"^^xsd:dateTime ;
+                                                                                                                  rdfs:label "Federal Public Prosecutor’s Office v. Érico Batista de Souza (Deforestation and climate damage in the PAE Antimary)" ;
+                                                                                                                  :url <https://climatecasechart.com/non-us-case/federal-public-prosecutors-office-v-erico-batista-de-souza-deforestation-and-climate-damage-in-the-pae-antimary/> .
+
+
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/src/parse_documents.py
+++ b/src/parse_documents.py
@@ -1,5 +1,4 @@
-from franz.openrdf.connect import ag_connect
-from franz.openrdf.vocabulary import RDF
+from src.ag_api import *
 import uuid
 import document_parser as dp
 import os
@@ -19,15 +18,11 @@ from selenium.webdriver.chrome.options import Options
 
 
 # Create a connection object and bind to conn. The conn object is used to connect with an AllegroGraph repository
-conn = ag_connect(repo='drmo', host='localhost', port=10035, user='test', password='xyzzy')
+
 
 # Set up variables bound to various classes and properties needed for this file
-section_class = conn.createURI("http://www.semanticweb.org/ontologies/2022/titutuli/nivedita/drmo#Section")
-document_class = conn.createURI("http://www.semanticweb.org/ontologies/2022/titutuli/nivedita/drmo#Document")
-domain_ont_str = "http://www.semanticweb.org/ontologies/2022/titutuli/nivedita/drmo#"
-rdfs_label_prop = conn.createURI("http://www.w3.org/2000/01/rdf-schema#label")
-text_prop = conn.createURI("http://www.semanticweb.org/ontologies/2022/titutuli/nivedita/drmo#text")
-sub_section_prop = conn.createURI("http://www.semanticweb.org/ontologies/2022/titutuli/nivedita/drmo#hasSubSection")
+document_class = conn.createURI("https://www.michaeldebellis.com/climate_obstruction/Document")
+text_prop = conn.createURI("https://www.michaeldebellis.com/climate_obstruction/text")
 iri_prop = conn.createURI("http://purl.org/ontology/bibo/uri")
 heading_prop = conn.createURI("http://www.semanticweb.org/ontologies/2022/titutuli/nivedita/drmo#heading")
 source_document = conn.createURI(
@@ -48,70 +43,12 @@ service = Service(ChromeDriverManager().install())
 
 
 
-
-
-# Gets the value of a single valued property using the IRI name of the instance and the IRI name of the property
-# If the property has multiple values prints a warning and returns the first one
-# If the property has no value returns None Note: if not sure whether property has multiple values, best to use get_values
-def get_value(instance, owl_property, debug=False):
-    if instance is None:
-        if debug:
-            print("Error no object with iri name: {iri_name}")
-        return None
-    statements = conn.getStatements(instance, owl_property, None)
-    with statements:
-        for statement in statements:
-            if len(statements) > 1:
-                if debug:
-                    print(f'Warning: two or more values for property: {owl_property}. Using first one.')
-                return statement.getObject()
-            elif len(statements) == 1:
-                return statement.getObject()
-    if debug:
-        print(f'Warning: No property value for: {instance, owl_property}.')
-    return None
-
-# When getting values that are datatypes there is all sorts of extra stuff we usually want to strip out
-# E.g., in the dest data below the result of get_value("MichaelDeBellis", "email") will be: "mdebellissf@gmail.com"^^<http://www.w3.org/2001/XMLSchema#anyURI>
-# this should strip out the datatype and extra string characters so will return mdebelissf@gmail.com
-def convert_to_string (literal):
-        literal = str(literal)
-        if "^" in literal:
-            literal = literal.replace(literal[literal.find("^") + len("^"):], '') #remove the datatype
-            literal = literal[1:len(literal) - 2] # remove the string characters and the remaining ^
-        return literal
-
-
 def get_url_for_document(document):
     url_string = get_value(document, iri_prop)
     if url_string is None:
         return None
     else:
         return convert_to_string(url_string)
-
-def create_sub_section(document, heading=None, text=None):
-    sub_section = conn.createURI(domain_ont_str + str(uuid.uuid4()))
-    conn.add(sub_section, RDF.TYPE, section_class)
-    if heading is not None:
-        conn.add(sub_section, heading_prop, heading)
-        conn.add(sub_section, rdfs_label_prop, heading)
-    if text is not None:
-        conn.add(sub_section, text_prop, text)
-    conn.add(document, sub_section_prop, sub_section)
-    return sub_section
-
-
-# Needed to create a set because graph was returning duplicates, not sure why but the documentation says that is possible
-# See: https://franz.com/agraph/support/documentation/current/python/api.html#repositoryresult-class
-# It may have been an issue in the ontology I was working on. I hadn't thought of this at the time
-# but it's possible in buggy versions of the code I asserted new values on the source object rather than the TestDocument
-# but I don't thin so.
-def display_sub_section(section):
-    print(get_value(section, heading_prop))
-    sub_section_statements = conn.getStatements(section, sub_section_prop, None)
-    section_set = set([section_statement.getObject() for section_statement in sub_section_statements])
-    for section in section_set:
-        display_sub_section(section)
 
 
 # This iterates over all documents and checks if the document has sub sections or a value for the text field
@@ -158,6 +95,16 @@ def extract_sciencedirect_links(csv_file_path):
                 links.extend(sciencedirect_link_pattern.findall(cell))
     return links
 
+def create_sub_section(document, heading=None, text=None):
+    sub_section = conn.createURI(domain_ont_str + str(uuid.uuid4()))
+    conn.add(sub_section, RDF.TYPE, section_class)
+    if heading is not None:
+        conn.add(sub_section, heading_prop, heading)
+        conn.add(sub_section, rdfs_label_prop, heading)
+    if text is not None:
+        conn.add(sub_section, text_prop, text)
+    conn.add(document, sub_section_prop, sub_section)
+    return sub_section
 
 # This function is used to build the sections for a document. It uses the document parser to get the sections
 


### PR DESCRIPTION
1) Got rid of conn create at the top as that is now handled in the ag_api.py file. From now on, I'll just call that api.  2) Removed convert_to_string, domain_ont_str function, rdfs_label_prop as they are now in the api.  3)Removed create_sub_section, display_sub_section, section_class,   sub_section_prop as they are no longer needed since we are storing all the strings on the document instance.  4) Changed string of document_class, text_prop for new ontology IRI. Also, changed the ontology a bit. Gist (the upper model we are starting from) has a class called Content that I was using as the superclass for all documents but I realized that class has a lot of sub classes that may be useful at some point but that won't have content we need to scrape from the Internet. It was easier to have one class that could be the superclass for all objects that could have scrapable (and vectorizable) content so I made Document a subclass of Content and made existing classes like Web_Page and Journal_Article, subclasses of Document.  5) Changed ontology to use the Bib uri property. Better to use the standard. I had forgotten about it and was just using a url property I created in the domain ontology.